### PR TITLE
general: update to dojson 1.1.0 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,57 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of DoJSON
+# This file is part of CDS-DoJSON
 # Copyright (C) 2015 CERN.
 #
-# DoJSON is free software; you can redistribute it and/or modify
+# CDS-DoJSON is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
+
+notifications:
+  email: false
 
 sudo: false
 
 language: python
 
+cache:
+- pip
+
+env:
+- REQUIREMENTS=lowest
+- REQUIREMENTS=release
+- REQUIREMENTS=devel
+
 python:
-#  - "2.6"
-  - "2.7"
-# FIXME esmre is not Python 3 compatible
-#  - "3.3"
-#  - "3.4"
+- '2.7'
+- '3.3'
+- '3.4'
+- '3.5'
+
+before_install:
+- travis_retry pip install --upgrade pip setuptools py
+- travis_retry pip install twine wheel coveralls requirements-builder
+- requirements-builder --level=min setup.py > .travis-lowest-requirements.txt
+- requirements-builder --level=pypi setup.py > .travis-release-requirements.txt
+- requirements-builder --level=dev --req requirements-devel.txt setup.py > .travis-devel-requirements.txt
 
 install:
-  - pip install --upgrade pip
-  - pip install coveralls pep257
-  - pip install pytest pytest-pep8 pytest-cov pytest-cache
-  - pip install -e .[docs,tests]
+- travis_retry pip install -r .travis-${REQUIREMENTS}-requirements.txt
+- travis_retry pip install -e .[all]
 
 script:
-  - pep257 --match-dir='cds_dojson' cds_dojson
-  - "sphinx-build -qnNW docs docs/_build/html"
-  - python setup.py test
+- "./run-tests.sh"
 
 after_success:
-  - coveralls
+- coveralls
 
-notifications:
-  email: false
+deploy:
+  provider: pypi
+  user: egebancho
+  password:
+    secure: uNcBmYTWCQVQBVnYaG3pTymPue+HA/tzHiQZDTLxb7Chd8dFT93CNPkdliQu733fu0epbYsGEGvdVl4R4jW3tN3lNxQ21/qS0AjrHuaxc3brc8pWF/8Nu7gkSuwAF19876A26Mn6NSvnAOa+HcRfgfELV4QBm3zZzdKXQvLkjr6Nu2eVxuGU/gvpy/9WxvCiL6uJQSBc8or/4v+icclpd9HlK7qqcZX9GEubGoR2027reGM2mHhIEETKdtQF/hzj0if9BTXAqOpwEqoWUvEtsteGu07qd0p8wWW95wWpO2eLK4CrPNex+bchPYBnqktj5cZbJl4zjQjotU1pfVzZyQrtYpsGRxjNUZZ8ponkKl5YeWLojJCwZHrYkEgg9ZFTd2rjjeqUUtotd/ihNsZ+prrYckbGHQjtWi2XGA/OekEtDzhk3zfy/0jo6epFaQxbmIPx/NK3C/Fsxh5/yivRXvoUgJt2MH5ZCuHuAz7X6RyHKCuKT6FEbvNORxyNTS4oJqiPRI5F4x6+wf4JAHiY0Ybsw+gpwhRgcdl1iRw1qAAs0ICoKUwWM0oPLX1/875DwCkImWBjYVgfoIh5eMlW79EgFmbBPS66TnGA/bCqStxyRMc7wCeS+KyDhGqCL+QMf/46TXZ0VtH/33X3+FL8Buauw6MoLUl5X1H+rFwOtuI=
+  on:
+    tags: true
+    distributions: sdist bdist_wheel
+    branch: master
+    repo: CERNDocumentServer/cds-dojson

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,6 @@
+Changes
+=======
+
+Version 0.2.0 (released 2016-02-29)
+
+- Initial public release.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -21,3 +21,8 @@ recursive-include docs Makefile
 recursive-include dojson *.py
 recursive-include dojson *.json
 recursive-include tests *.py
+
+# added by check_manifest.py
+include *.txt
+recursive-include cds_dojson *.py
+recursive-include tests *.xml

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,0 +1,27 @@
+==================
+CDS-DoJSON v0.2.0
+==================
+
+DoJSON v0.2.0 was released on February 29, 2016.
+
+About
+-----
+
+CDS DoJSON is an extension of DoJSON package with the customization for CDS.
+
+Installation
+------------
+
+   $ pip install cds-dojson==0.2.0
+
+Documentation
+-------------
+
+    http://cds-dojson.readthedocs.org/en/v0.2.0
+
+    Happy hacking and thanks for flying DoJSON.
+
+    | CERN Document Serveer Team
+    |   Email: cds.support@cern.ch
+    |   GitHub: https://github.com/CERNDocumentServer/cds-dojson
+    |   URL: https://cds.cern.ch

--- a/cds_dojson/marc21/fields/album.py
+++ b/cds_dojson/marc21/fields/album.py
@@ -19,12 +19,12 @@
 
 """CDS Album MARC 21 field definitions."""
 
-from cds_dojson.marc21.models.album import model as marc21
-
 from dojson import utils
 
+from cds_dojson.marc21.models.album import model as marc21
 
-@marc21.over('images', '^774[10_][8_]', override=True)
+
+@marc21.over('images', '^774[_01][_8]', override=True)
 @utils.for_each_value
 @utils.filter_values
 def images(self, key, value):

--- a/cds_dojson/marc21/fields/default/bd01x09x.py
+++ b/cds_dojson/marc21/fields/default/bd01x09x.py
@@ -19,9 +19,9 @@
 
 """CDS special/custom tags."""
 
-from cds_dojson.marc21.models.default import model as marc21
-
 from dojson import utils
+
+from cds_dojson.marc21.models.default import model as marc21
 
 
 @marc21.over('international_standard_number', '^021..')

--- a/cds_dojson/marc21/fields/default/bd2xx.py
+++ b/cds_dojson/marc21/fields/default/bd2xx.py
@@ -19,10 +19,10 @@
 
 """CDS special/custom tags."""
 
+from dojson import utils
+
 from cds_dojson import utils as cds_utils
 from cds_dojson.marc21.models.default import model as marc21
-
-from dojson import utils
 
 
 @marc21.over('imprint', '^269__')

--- a/cds_dojson/marc21/fields/default/bd2xx.py
+++ b/cds_dojson/marc21/fields/default/bd2xx.py
@@ -25,49 +25,6 @@ from cds_dojson.marc21.models.default import model as marc21
 from dojson import utils
 
 
-@marc21.over('title_statement', '^245[10_][_1032547698]', override=True)
-@cds_utils.for_each_squash
-@utils.filter_values
-def title_statement(self, key, value):
-    """Title Statement."""
-    indicator_map1 = {"0": "No added entry", "1": "Added entry"}
-    indicator_map2 = {
-        "0": "No nonfiling characters",
-        "1": "Number of nonfiling characters",
-        "2": "Number of nonfiling characters",
-        "3": "Number of nonfiling characters",
-        "4": "Number of nonfiling characters",
-        "5": "Number of nonfiling characters",
-        "6": "Number of nonfiling characters",
-        "7": "Number of nonfiling characters",
-        "8": "Number of nonfiling characters",
-        "9": "Number of nonfiling characters"}
-    return {
-        'title': value.get('a'),
-        'statement_of_responsibility': value.get('c'),
-        'remainder_of_title': value.get('b'),
-        'bulk_dates': value.get('g'),
-        'inclusive_dates': value.get('f'),
-        'medium': value.get('h'),
-        'form': utils.force_list(
-            value.get('k')
-        ),
-        'number_of_part_section_of_a_work': utils.force_list(
-            value.get('n')
-        ),
-        'name_of_part_section_of_a_work': utils.force_list(
-            value.get('p')
-        ),
-        'version': value.get('s'),
-        'linkage': value.get('6'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
-        'title_added_entry': indicator_map1.get(key[3]),
-        'nonfiling_characters': indicator_map2.get(key[4]),
-    }
-
-
 @marc21.over('imprint', '^269__')
 @utils.for_each_value
 @utils.filter_values

--- a/cds_dojson/marc21/fields/default/bd5xx.py
+++ b/cds_dojson/marc21/fields/default/bd5xx.py
@@ -19,9 +19,9 @@
 
 """CDS special/custom tags."""
 
-from cds_dojson.marc21.models.default import model as marc21
-
 from dojson import utils
+
+from cds_dojson.marc21.models.default import model as marc21
 
 
 @marc21.over('french_summary_note', '^590__')

--- a/cds_dojson/marc21/fields/default/bd6xx.py
+++ b/cds_dojson/marc21/fields/default/bd6xx.py
@@ -19,9 +19,9 @@
 
 """CDS special/custom tags."""
 
-from cds_dojson.marc21.models.default import model as marc21
-
 from dojson import utils
+
+from cds_dojson.marc21.models.default import model as marc21
 
 
 @marc21.over('index_term_uncontrolled', '^653[10_2][_1032546]', override=True)

--- a/cds_dojson/marc21/fields/default/bd7xx.py
+++ b/cds_dojson/marc21/fields/default/bd7xx.py
@@ -19,9 +19,9 @@
 
 """CDS special/custom tags."""
 
-from cds_dojson.marc21.models.default import model as marc21
-
 from dojson import utils
+
+from cds_dojson.marc21.models.default import model as marc21
 
 
 @marc21.over('added_entry_corporate_name', '^710[10_2][_2]$', override=True)

--- a/cds_dojson/marc21/fields/default/bd8xx.py
+++ b/cds_dojson/marc21/fields/default/bd8xx.py
@@ -19,9 +19,9 @@
 
 """CDS special/custom tags."""
 
-from cds_dojson.marc21.models.default import model as marc21
-
 from dojson import utils
+
+from cds_dojson.marc21.models.default import model as marc21
 
 
 @marc21.over('electronic_mail_message', '^859__')

--- a/cds_dojson/marc21/fields/default/bd9xx.py
+++ b/cds_dojson/marc21/fields/default/bd9xx.py
@@ -19,10 +19,10 @@
 
 """CDS special/custom tags."""
 
+from dojson import utils
+
 from cds_dojson import utils as cds_utils
 from cds_dojson.marc21.models.default import model as marc21
-
-from dojson import utils
 
 
 @marc21.over('affiliation_at_conversion', '^901__')
@@ -34,7 +34,7 @@ def affiliation_at_conversion(self, key, value):
     }
 
 
-@marc21.over('grey_book', '^903__')
+@marc21.over('grey_book', '^903__$')
 @utils.for_each_value
 @utils.filter_values
 def grey_book(self, key, value):
@@ -47,7 +47,7 @@ def grey_book(self, key, value):
     }
 
 
-@marc21.over('approval_status_history', '^9031_')
+@marc21.over('approval_status_history', '^9031_$')
 @utils.for_each_value
 @utils.filter_values
 def approval_status_history(self, key, value):

--- a/cds_dojson/marc21/fields/image.py
+++ b/cds_dojson/marc21/fields/image.py
@@ -19,12 +19,12 @@
 
 """CDS Image MARC 21 field definitions."""
 
-from cds_dojson.marc21.models.image import model as marc21
-
 from dojson import utils
 
+from cds_dojson.marc21.models.image import model as marc21
 
-@marc21.over('album_parent', '^774[10_][8_]', override=True)
+
+@marc21.over('album_parent', '^774[_01][_8]', override=True)
 @utils.for_each_value
 def album_parent(self, key, value):
     """Album ID which contains this photo"""
@@ -34,7 +34,7 @@ def album_parent(self, key, value):
     }
 
 
-@marc21.over('image_url', '^856.[10_28]', override=True)
+@marc21.over('image_url', '^856[_012347][_0128]', override=True)
 @utils.for_each_value
 @utils.filter_values
 def image_url(self, key, value):

--- a/cds_dojson/marc21/fields/video.py
+++ b/cds_dojson/marc21/fields/video.py
@@ -19,9 +19,9 @@
 
 """CDS special/custom tags."""
 
-from cds_dojson.marc21.models.video import model as marc21
-
 from dojson import utils
+
+from cds_dojson.marc21.models.video import model as marc21
 
 
 @marc21.over('physical_description', '^300..', override=True)

--- a/cds_dojson/marc21/models/album.py
+++ b/cds_dojson/marc21/models/album.py
@@ -30,3 +30,18 @@ class CDSAlbum(Overdo):
 
 model = CDSAlbum(bases=(cds_marc21, ),
                  entry_point_group='cds_dojson.marc21.album')
+
+
+@model.over('__order__', '__order__', override=True)
+def order(self, key, value):
+    """Preserve order of datafields."""
+    order = []
+    for field in value:
+        name = model.index.query(field)
+        if name:
+            name = name[0]
+        else:
+            name = field
+        order.append(name)
+
+    return order

--- a/cds_dojson/marc21/models/default.py
+++ b/cds_dojson/marc21/models/default.py
@@ -32,3 +32,18 @@ class CDSMarc21(Overdo):
 
 model = CDSMarc21(bases=(marc21, ),
                   entry_point_group='cds_dojson.marc21.default')
+
+
+@model.over('__order__', '__order__', override=True)
+def order(self, key, value):
+    """Preserve order of datafields."""
+    order = []
+    for field in value:
+        name = model.index.query(field)
+        if name:
+            name = name[0]
+        else:
+            name = field
+        order.append(name)
+
+    return order

--- a/cds_dojson/marc21/models/image.py
+++ b/cds_dojson/marc21/models/image.py
@@ -30,3 +30,18 @@ class CDSImage(Overdo):
 
 model = CDSImage(bases=(cds_marc21, ),
                  entry_point_group='cds_dojson.marc21.image')
+
+
+@model.over('__order__', '__order__', override=True)
+def order(self, key, value):
+    """Preserve order of datafields."""
+    order = []
+    for field in value:
+        name = model.index.query(field)
+        if name:
+            name = name[0]
+        else:
+            name = field
+        order.append(name)
+
+    return order

--- a/cds_dojson/marc21/models/video.py
+++ b/cds_dojson/marc21/models/video.py
@@ -30,3 +30,18 @@ class CDSVideo(Overdo):
 
 model = CDSVideo(bases=(cds_marc21, ),
                  entry_point_group='cds_dojson.marc21.video')
+
+
+@model.over('__order__', '__order__', override=True)
+def order(self, key, value):
+    """Preserve order of datafields."""
+    order = []
+    for field in value:
+        name = model.index.query(field)
+        if name:
+            name = name[0]
+        else:
+            name = field
+        order.append(name)
+
+    return order

--- a/cds_dojson/marc21/utils.py
+++ b/cds_dojson/marc21/utils.py
@@ -19,12 +19,12 @@
 
 """Utilities for converting MARC21."""
 
-from dojson.contrib.marc21.utils import create_record, split_blob
+from dojson.contrib.marc21.utils import create_record, split_stream
 
 
 def load(source):
     """Load MARC XML and return Python dict."""
-    for data in split_blob(source.read()):
+    for data in split_stream(source):
         record = create_record(data)
         # if record.get('999__', {}).get('a', '') == 'ALBUM':
         #     for rrecord in split_album(record):

--- a/cds_dojson/matcher.py
+++ b/cds_dojson/matcher.py
@@ -20,12 +20,13 @@
 """Query parser."""
 
 import logging
+
 import pkg_resources
 import pypeg2
 
-from invenio_query_parser.walkers.pypeg_to_ast import PypegConverter
 from invenio_query_parser.parser import Main as parser
 from invenio_query_parser.walkers.match_unit import MatchUnit
+from invenio_query_parser.walkers.pypeg_to_ast import PypegConverter
 
 
 class Query(object):
@@ -47,7 +48,10 @@ class Query(object):
 
 
 def matcher(record, entry_point_group):
-    """DoJSON model matcher.
+    """Matcher for DoJSON models.
+
+    Using ``invenio-query-parser`` and ``MatchUnit`` walker decide which of the
+    DoJSON models will be use depending on the content of the record.
 
     :param record: Something that looks like a python dictionary
 
@@ -55,7 +59,6 @@ def matcher(record, entry_point_group):
     """
     logger = logging.getLogger(__name__ + ".dojson_matcher")
 
-    _smart_dict_record = dict(record)
     _matches = []
     default = None
     for entry_point in pkg_resources.iter_entry_points(entry_point_group):
@@ -64,7 +67,7 @@ def matcher(record, entry_point_group):
         if entry_point.name == 'default':
             default = model
 
-        if query.match(_smart_dict_record):
+        if query.match(record):
             logger.info("Model `{0}` found matching the query {1}.".format(
                 entry_point.name, model
             ))
@@ -75,7 +78,7 @@ def matcher(record, entry_point_group):
             logger.error(
                 ("Found more than one matches `{0}`, we'll use {1}"
                  " for record {2}.").format(
-                    _matches, default, _smart_dict_record
+                    _matches, default, record
                 )
             )
             return default
@@ -83,7 +86,7 @@ def matcher(record, entry_point_group):
     except IndexError:
         logger.warning(
             "Model *not* found, fallback to default {0} for record {1}".format(
-                default, _smart_dict_record
+                default, record
             )
         )
         return default

--- a/cds_dojson/overdo.py
+++ b/cds_dojson/overdo.py
@@ -37,9 +37,13 @@ class OverdoBase(DoJSONOverdo):
         """Not to be used in this class."""
         raise NotImplementedError()
 
-    def do(self, blob):
+    def do(self, blob, **kwargs):
         """Translate blob values and instantiate new model instance."""
-        return matcher(blob, self.entry_point_models).do(blob)
+        return matcher(blob, self.entry_point_models).do(blob, **kwargs)
+
+    def missing(self, blob, **kwargs):
+        """Translate blob values and instantiate new model instance."""
+        return matcher(blob, self.entry_point_models).missing(blob, **kwargs)
 
 
 class Overdo(DoJSONOverdo):

--- a/cds_dojson/to_marc21/fields/album.py
+++ b/cds_dojson/to_marc21/fields/album.py
@@ -19,9 +19,9 @@
 
 """CDS Album MARC 21 field definitions."""
 
-from cds_dojson.to_marc21.models.album import model as to_marc21
-
 from dojson import utils
+
+from cds_dojson.to_marc21.models.album import model as to_marc21
 
 
 @to_marc21.over('774', 'images', override=True)

--- a/cds_dojson/to_marc21/fields/default/bd9xx.py
+++ b/cds_dojson/to_marc21/fields/default/bd9xx.py
@@ -33,34 +33,29 @@ def affiliation_at_conversion(self, key, value):
     }
 
 
-@to_marc21.over('903', '^grey_book$')
-@utils.reverse_for_each_value
-@utils.filter_values
-def grey_book(self, key, value):
-    """Grey book."""
-    return {
-        'a': value.get('approval'),
-        'b': value.get('beam'),
-        'd': value.get('status_date'),
-        's': value.get('status'),
-    }
-
-
-@to_marc21.over('903', '^approval_status_history$')
+@to_marc21.over('903', '^approval_status_history$|^grey_book$')
 @utils.reverse_for_each_value
 @utils.filter_values
 def approval_status_history(self, key, value):
     """Approval status history."""
-    return {
-        'a': value.get('description'),
-        'b': value.get('report_number'),
-        'c': value.get('category'),
-        'd': value.get('date'),
-        'e': value.get('deadline'),
-        'f': value.get('e-mail'),
-        's': value.get('status'),
-        '$ind1': '1',
-    }
+    if any(k in value for k in ('approval', 'beam', 'status_week')):
+        return {
+            'a': value.get('approval'),
+            'b': value.get('beam'),
+            'd': value.get('status_date'),
+            's': value.get('status'),
+        }
+    else:
+        return {
+            'a': value.get('description'),
+            'b': value.get('report_number'),
+            'c': value.get('category'),
+            'd': value.get('date'),
+            'e': value.get('deadline'),
+            'f': value.get('e-mail'),
+            's': value.get('status'),
+            '$ind1': '1',
+        }
 
 
 @to_marc21.over('905', '^spokesman$')
@@ -270,48 +265,38 @@ def additional_subject_added_entry_topical_term(self, key, value):
     }
 
 
-@to_marc21.over('999', '^references$')
+@to_marc21.over('999', '^references$|^refextract_references$|^record_type$')
 @utils.reverse_for_each_value
 @utils.filter_values
 def references(self, key, value):
     """References."""
-    return {
-        'a': value.get('doi'),
-        'h': value.get('authors'),
-        'm': utils.reverse_force_list(
-            value.get('miscellaneous')
-        ),
-        'n': value.get('issue_number'),
-        'o': value.get('order_number'),
-        'p': value.get('page'),
-        'r': value.get('report_number'),
-        's': value.get('journal_publication_note'),
-        't': value.get('journal_title_abbreviation'),
-        'u': value.get('uniform_resource_identifier'),
-        'v': value.get('volume'),
-        'y': value.get('year'),
-        '$ind1': 'C',
-        '$ind2': '5',
-    }
-
-
-@to_marc21.over('999', '^refextract_references$')
-@utils.reverse_for_each_value
-def refexctract_references(self, key, value):
-    """Refextract references."""
-    return {
-        'a': value.get('refextract_info'),
-        '$ind1': 'C',
-        '$ind2': '6',
-    }
-
-
-@to_marc21.over('999', '^record_type$')
-@utils.reverse_for_each_value
-@utils.filter_values
-def record_type(self, key, value):
-    """Record type - mostly IMAGE."""
-    return {
-        'a': value.get('record_type'),
-        '9': value.get('dump'),
-    }
+    if 'refextract_info' in value:
+        return {
+            'a': value.get('refextract_info'),
+            '$ind1': 'C',
+            '$ind2': '6',
+        }
+    elif 'record_type' in value:
+        return {
+            'a': value.get('record_type'),
+            '9': value.get('dump'),
+        }
+    else:
+        return {
+            'a': value.get('doi'),
+            'h': value.get('authors'),
+            'm': utils.reverse_force_list(
+                value.get('miscellaneous')
+            ),
+            'n': value.get('issue_number'),
+            'o': value.get('order_number'),
+            'p': value.get('page'),
+            'r': value.get('report_number'),
+            's': value.get('journal_publication_note'),
+            't': value.get('journal_title_abbreviation'),
+            'u': value.get('uniform_resource_identifier'),
+            'v': value.get('volume'),
+            'y': value.get('year'),
+            '$ind1': 'C',
+            '$ind2': '5',
+        }

--- a/cds_dojson/to_marc21/fields/image.py
+++ b/cds_dojson/to_marc21/fields/image.py
@@ -19,9 +19,9 @@
 
 """CDS Image MARC 21 field definitions."""
 
-from cds_dojson.to_marc21.models.image import model as to_marc21
-
 from dojson import utils
+
+from cds_dojson.to_marc21.models.image import model as to_marc21
 
 
 @to_marc21.over('774', '^album_parent$', override=True)

--- a/cds_dojson/to_marc21/fields/video.py
+++ b/cds_dojson/to_marc21/fields/video.py
@@ -19,9 +19,9 @@
 
 """CDS special/custom tags."""
 
-from cds_dojson.to_marc21.models.video import model as to_marc21
-
 from dojson import utils
+
+from cds_dojson.to_marc21.models.video import model as to_marc21
 
 
 @to_marc21.over('300', '^physical_description$', override=True)

--- a/cds_dojson/to_marc21/models/album.py
+++ b/cds_dojson/to_marc21/models/album.py
@@ -21,8 +21,8 @@
 
 from dojson.contrib.to_marc21.model import Underdo
 
-from .default import model as cds_to_marc21
 from ...overdo import Overdo
+from .default import model as cds_to_marc21
 
 
 class CDSToAlbum(Overdo, Underdo):

--- a/cds_dojson/to_marc21/models/image.py
+++ b/cds_dojson/to_marc21/models/image.py
@@ -21,8 +21,8 @@
 
 from dojson.contrib.to_marc21.model import Underdo
 
-from .default import model as cds_to_marc21
 from ...overdo import Overdo
+from .default import model as cds_to_marc21
 
 
 class CDSToImage(Overdo, Underdo):

--- a/cds_dojson/to_marc21/models/video.py
+++ b/cds_dojson/to_marc21/models/video.py
@@ -21,8 +21,8 @@
 
 from dojson.contrib.to_marc21.model import Underdo
 
-from .default import model as cds_to_marc21
 from ...overdo import Overdo
+from .default import model as cds_to_marc21
 
 
 class CDSToVideo(Overdo, Underdo):

--- a/cds_dojson/utils.py
+++ b/cds_dojson/utils.py
@@ -20,8 +20,9 @@
 """The CDS DoJson Utils."""
 
 import functools
-import six
 from collections import defaultdict
+
+import six
 
 
 def for_each_squash(f):

--- a/cds_dojson/version.py
+++ b/cds_dojson/version.py
@@ -17,4 +17,4 @@ This file is imported by ``cds-dojson.__init__``, and parsed by
 # Do not change the format of this next line. Doing so risks breaking
 # setup.py and docs/conf.py
 
-__version__ = "0.2.0"
+__version__ = "0.2.0.dev20160229"

--- a/cds_dojson/version.py
+++ b/cds_dojson/version.py
@@ -17,4 +17,4 @@ This file is imported by ``cds-dojson.__init__``, and parsed by
 # Do not change the format of this next line. Doing so risks breaking
 # setup.py and docs/conf.py
 
-__version__ = "0.2.0.dev20160229"
+__version__ = "0.2.0"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,6 @@ import os
 import re
 import sys
 
-
 _html_theme = "sphinx_rtd_theme"
 _html_theme_path = []
 try:
@@ -42,6 +41,7 @@ except ImportError:
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.todo',
+    'sphinx.ext.doctest',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -57,8 +57,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'DoJSON'
-copyright = u'2014, Invenio collaboration'
+project = u'CDS-DoJSON'
+copyright = u'2014, CERN Document Server'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -197,7 +197,7 @@ html_theme_path = _html_theme_path
 # html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'DoJSONdoc'
+htmlhelp_basename = 'CDSDoJSONdoc'
 
 
 # -- Options for LaTeX output ---------------------------------------------
@@ -217,8 +217,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    ('index', 'DoJSON.tex', u'DoJSON Documentation',
-     u'Invenio collaboration', 'manual'),
+    ('index', 'CDS-DoJSON.tex', u'CDS DoJSON Documentation',
+     u'CERN Document Server', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -247,8 +247,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'invenioqueryparser', u'DoJSON Documentation',
-     [u'Invenio collaboration'], 1)
+    ('index', 'cdsdojson', u'CDS DoJSON Documentation',
+     [u'CERN Document Server'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -261,8 +261,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    ('index', 'DoJSON', u'DoJSON Documentation',
-     u'Invenio collaboration', 'DoJSON', 'One line description of project.',
+    ('index', 'CDS-DoJSON', u'CDS DoJSON Documentation',
+     u'CERN Document Server', 'CDS-DoJSON', 'One line description of project.',
      'Miscellaneous'),
 ]
 

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,1 +1,2 @@
+-e git+https://github.com/inveniosoftware/dojson.git@master#egg=dojson
 -e git+https://github.com/inveniosoftware/invenio-query-parser.git@master#egg=invenio-query-parser

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -7,6 +7,9 @@
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 
-pep257 --match-dir='cds_dojson' cds_dojson && \
+pydocstyle --match-dir='cds_dojson' cds_dojson && \
+# isort -rc -c -df -o dojson **/*.py && \
+check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
-python setup.py test
+python setup.py test && \
+sphinx-build -qnNW -b doctest docs docs/_build/doctest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,20 @@
+# This file is part of CDS-DoJSON
+# Copyright (C) 2015, 2016 CERN.
+#
+# CDS-DoJSON is free software; you can redistribute it and/or
+# modify it under the terms of the Revised BSD License; see LICENSE
+# file for more details.
+
+[aliases]
+test=pytest
+
+[build_sphinx]
+source-dir = docs/
+build-dir = docs/_build
+all_files = 1
+
+[bdist_wheel]
+universal = 1
+
+[upload_sphinx]
+upload-dir = docs/_build/html

--- a/setup.py
+++ b/setup.py
@@ -7,87 +7,65 @@
 # modify it under the terms of the Revised BSD License; see LICENSE
 # file for more details.
 
-"""DoJSON is a simple Pythonic JSON to JSON converter."""
+"""CDS DoJSON extension"""
 
 import os
 import re
-import sys
 
-from setuptools import find_packages, setup
-from setuptools.command.test import test as TestCommand
-
-
-class PyTest(TestCommand):
-
-    """PyTest test runner.
-
-    See: http://pytest.org/latest/goodpractises.html?highlight=setuptools
-    """
-
-    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
-
-    def initialize_options(self):
-        """Initialise test options."""
-        TestCommand.initialize_options(self)
-        try:
-            from ConfigParser import ConfigParser
-        except ImportError:
-            from configparser import ConfigParser
-        config = ConfigParser()
-        config.read("pytest.ini")
-        self.pytest_args = config.get("pytest", "addopts").split(" ")
-
-    def finalize_options(self):
-        """Finalise test options."""
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        """Rest tests."""
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
-
+from setuptools import setup
 
 # Get the version string.  Cannot be done with import!
-g = {}
-with open(os.path.join('cds_dojson', 'version.py'), 'rt') as fp:
-    exec(fp.read(), g)
-    version = g['__version__']
+with open(os.path.join('cds_dojson', 'version.py'), 'rt') as f:
+    version = re.search(
+        '__version__\s*=\s*"(?P<version>.*)"\n',
+        f.read()
+    ).group('version')
 
 tests_require = [
+    'check-manifest>=0.25',
+    'coverage>=4.0',
+    'isort>=4.2.2',
+    'mock>=1.0.0',
+    'pydocstyle>=1.0.0',
     'pytest-cache>=1.0',
     'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',
     'pytest>=2.8.0',
-    'coverage>=4.0.0',
-    'mock',
 ]
+
+extras_require = {
+    'docs': [
+        'Sphinx>=1.3',
+    ],
+    'tests': tests_require,
+}
+
+extras_require['all'] = []
+for name, reqs in extras_require.items():
+    extras_require['all'].extend(reqs)
 
 setup(
     name='cds-dojson',
     version=version,
     url='http://github.com/CERNDocumentServer/cds-dojson/',
     license='BSD',
-    author='Invenio collaboration',
-    author_email='info@invenio-software.org',
+    author='CERN Document Server Team',
+    author_email='cds-support@cern.ch',
     description=__doc__,
     long_description=open('README.rst').read(),
-    packages=find_packages(),
+    packages=['cds_dojson'],
     zip_safe=False,
     include_package_data=True,
     platforms='any',
-    install_requires=[
-        'dojson>=0.1.1',
-        'invenio-query-parser>=0.3.0',
-        'pyPEG2>=2.15.1',
+    setup_requires=[
+        'pytest-runner>=2.6.2',
+        'setuptools>=17.1',
     ],
-    extras_require={
-        'docs': ['sphinx_rtd_theme'],
-        'tests': tests_require,
-    },
+    install_requires=[
+        'dojson>=1.1.0',
+        'invenio-query-parser>=0.5.0',
+    ],
+    extras_require=extras_require,
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
@@ -95,7 +73,6 @@ setup(
         'Programming Language :: Python',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
@@ -103,7 +80,6 @@ setup(
         'Development Status :: 5 - Production/Stable',
     ],
     tests_require=tests_require,
-    cmdclass={'test': PyTest},
     entry_points={
         'cds_dojson.marc21.models': [
             'album = cds_dojson.marc21.models.album:model',

--- a/tests/test_cds_dojson_image.py
+++ b/tests/test_cds_dojson_image.py
@@ -22,12 +22,14 @@
 from __future__ import absolute_import
 
 import json
+
 from click.testing import CliRunner
+from dojson.contrib.marc21.utils import create_record
 
 from cds_dojson.marc21.models.image import model as marc21
 from cds_dojson.matcher import matcher
 from cds_dojson.to_marc21.models.image import model as to_marc21
-from dojson.contrib.marc21.utils import create_record
+
 
 CDS_IMAGE = """
 <record>
@@ -154,11 +156,18 @@ def test_cli_do_cds_marc21_from_xml():
 
     with runner.isolated_filesystem():
         with open('record.xml', 'wb') as f:
-            f.write(CDS_IMAGE)
+            f.write(CDS_IMAGE.encode('utf-8'))
 
         result = runner.invoke(
-            cli.apply_rule,
-            ['-i', 'record.xml', '-l', 'cds_marcxml', 'cds_marc21']
+            cli.cli,
+            ['-i', 'record.xml', '-l', 'cds_marcxml', 'missing', 'cds_marc21']
+        )
+        assert '' == result.output
+        assert 0 == result.exit_code
+
+        result = runner.invoke(
+            cli.cli,
+            ['-i', 'record.xml', '-l', 'cds_marcxml', 'do', 'cds_marc21']
         )
         data = json.loads(result.output)[0]
 

--- a/tests/test_cds_to_marc21_fields_default.py
+++ b/tests/test_cds_to_marc21_fields_default.py
@@ -22,11 +22,13 @@
 from __future__ import absolute_import
 
 import json
-from click.testing import CliRunner
 
+from click.testing import CliRunner
 from dojson.contrib.marc21.utils import create_record
+
 from cds_dojson.marc21.models.default import model as marc21
 from cds_dojson.to_marc21.models.default import model as to_marc21
+
 
 RECORD_SIMPLE = """
 <record>

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -17,9 +17,8 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02D111-1307, USA.
 
+from cds_dojson.marc21.models import album, default, image, video
 from cds_dojson.matcher import matcher
-
-from cds_dojson.marc21.models import *
 
 
 def test_marc21_matcher():
@@ -29,7 +28,7 @@ def test_marc21_matcher():
     duplicated_blob = {'999__': [{'a': 'IMAGE'}, {'a': 'ALBUM'}]}
     image_blob = {'999__': {'a': 'IMAGE'}}
     no_match_blob = {'000__': {'z': 'odd'}}
-    video_blob = {'999__': {'a': 'PUBLVIDEOMOVIE'}}
+    video_blob = {'980__': {'a': 'PUBLVIDEOMOVIE'}}
 
     assert album.model == matcher(album_blob, 'cds_dojson.marc21.models')
     assert default.model == matcher(cern_blob, 'cds_dojson.marc21.models')
@@ -37,3 +36,4 @@ def test_marc21_matcher():
         duplicated_blob, 'cds_dojson.marc21.models')
     assert default.model == matcher(no_match_blob, 'cds_dojson.marc21.models')
     assert image.model == matcher(image_blob, 'cds_dojson.marc21.models')
+    assert video.model == matcher(video_blob, 'cds_dojson.marc21.models')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,8 +19,9 @@
 
 from __future__ import absolute_import
 
-from cds_dojson.utils import for_each_squash
 from dojson.utils import filter_values
+
+from cds_dojson.utils import for_each_squash
 
 
 def test_for_each_squash():


### PR DESCRIPTION
* Updates tests to the new API. (closes #6)

* Removes unnecessary transformations in `matcher.py`.

* Changes `pep257` to `pydocstyle`. (closes #8)

* Adds development requirements to allow travis building for latest
  `dojson` and `invenio-query-parser` versions.

* Fixes wrong field regexp for `9XX` fields.