### PR TITLE
schemas: complied video schemas

### DIFF
--- a/cds_dojson/cli.py
+++ b/cds_dojson/cli.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CERN Document Server.
+# Copyright (C) 2016 CERN.
+#
+# CERN Document Server is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CERN Document Server is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with CERN Document Server; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""CLI additions to ``dojson``."""
+
+from __future__ import absolute_import, print_function
+
+import os
+import json
+
+import click
+
+from .schemas.tranform import compile_schema as _compile_schema
+
+
+@click.group()
+def cli():
+    """CDS dojson CLI."""
+    pass
+
+
+@cli.command()
+@click.argument('schema', type=click.Path(exists=True))
+def compile_schema(schema):
+    """Compile ``$ref`` and ``allOf`` key from the given JSON schema."""
+    with open(schema) as f:
+        schema_json = json.load(f)
+
+    base_uri = 'file://{0}/'.format(os.path.dirname(os.path.abspath(schema)))
+
+    click.echo(json.dumps(_compile_schema(schema_json, base_uri), indent=2))

--- a/cds_dojson/schemas/deposits/records/project-v1.0.0.json
+++ b/cds_dojson/schemas/deposits/records/project-v1.0.0.json
@@ -1,76 +1,1220 @@
 {
+  "title": "CDS Deposit Project Schema.",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "title": "Deposit schema.",
-  "description": "Describe information needed for deposit module.",
   "properties": {
-    "basic_info": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "title": "Name"
+    "project": {
+      "definitions": {
+        "title": {
+          "description": "A name given to the resource. Typically, a Title will be a name by which the resource is formally known.",
+          "additionalProperties": false,
+          "required": [
+            "title"
+          ],
+          "properties": {
+            "title": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "subtitle": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "creator": {
+          "description": "An entity primarily responsible for making the resource. Examples of a Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity.",
+          "additionalProperties": false,
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "email": {
+              "format": "email",
+              "description": "Contact email for the purpose of this specific record.",
+              "type": "string"
+            },
+            "contribution": {
+              "description": "Specific contribution of the person to this specific record.",
+              "type": "string"
+            },
+            "affiliations": {
+              "items": {
+                "type": "string"
+              },
+              "uniqueItems": true,
+              "description": "Affiliation(s) for the purpose of this specific record.",
+              "type": "array"
+            },
+            "name": {
+              "description": "Full name of person. Personal name format: family, given.",
+              "type": "string"
+            },
+            "ids": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "source": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "uniqueItems": true,
+              "description": "List of IDs related with the person.",
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "language": {
+          "description": "A language of the resource.",
+          "type": "string"
+        },
+        "copyright": {
+          "description": ".",
+          "properties": {
+            "year": {
+              "format": "date-time",
+              "description": "The year during which the claimed copyright for the CreativeWork was first asserted.",
+              "type": "string"
+            },
+            "holder": {
+              "description": "The party holding the legal copyright to the record.",
+              "type": "string"
+            },
+            "url": {
+              "format": "url",
+              "type": "string"
+            }
+          },
+          "type": "object"
         },
         "description": {
-          "type": "string",
-          "title": "Description"
-        }
-      }
-    },
-    "$schema": {
-      "type": "string"
-    },
-    "_deposit": {
-      "type": "object",
-      "name": "_deposit",
-      "properties": {
-        "id": {
-          "type": "string",
-          "name": "id"
-        },
-        "pid": {
-          "type": "object",
-          "name": "pid",
+          "description": "An account of the resource. Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource.",
+          "additionalProperties": false,
+          "required": [
+            "value"
+          ],
           "properties": {
-            "revision_id": {
-              "type": "integer"
-            },
-            "type": {
+            "source": {
               "type": "string"
             },
             "value": {
               "type": "string"
             }
-          }
+          },
+          "type": "object"
         },
-        "created_by": {
-          "type": "integer",
-          "name": "created_by"
-        },
-        "owners": {
-          "type": "array",
-          "name": "owners",
-          "items": [
-            {
-              "type": "integer"
+        "keywords": {
+          "items": {
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
             }
-          ]
+          },
+          "description": "",
+          "type": "array"
         },
-        "status": {
-          "type": "string",
-          "name": "status",
-          "enum": [
-            "draft",
-            "published"
-          ]
+        "identifier": {
+          "additionalProperties": false,
+          "description": "An unambiguous reference to the resource within a given context.",
+          "properties": {
+            "source": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "license": {
+          "description": "A license document that applies to this content, typically indicated by URL.",
+          "type": "string"
+        },
+        "date": {
+          "format": "date-time",
+          "description": "A point or period of time associated with an event in the lifecycle of the resource. (http://www.w3.org/TR/NOTE-datetime)",
+          "type": "string"
+        },
+        "contributor": {
+          "description": "An entity responsible for making contributions to the resource. Examples of a Contributor include a person, an organization, or a service. Typically, the name of a Contributor should be used to indicate the entity.",
+          "additionalProperties": false,
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "email": {
+              "format": "email",
+              "description": "Contact email for the purpose of this specific record.",
+              "type": "string"
+            },
+            "role": {
+              "type": "string"
+            },
+            "name": {
+              "description": "Full name of person. Personal name format: family, given.",
+              "type": "string"
+            },
+            "contribution": {
+              "description": "Specific contribution of the person to this specific record.",
+              "type": "string"
+            },
+            "affiliations": {
+              "items": {
+                "type": "string"
+              },
+              "uniqueItems": true,
+              "description": "Affiliation(s) for the purpose of this specific record.",
+              "type": "array"
+            },
+            "ids": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "source": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "uniqueItems": true,
+              "description": "List of IDs related with the person.",
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "file": {
+          "description": "A file object described using some basic subfields. (Usually to be extended).",
+          "properties": {
+            "key": {
+              "type": "string"
+            },
+            "checksum": {
+              "type": "string"
+            },
+            "category": {
+              "description": "Former BibDocFile.doctype.",
+              "type": "string"
+            },
+            "bucket": {
+              "type": "string"
+            },
+            "size": {
+              "type": "integer"
+            },
+            "type": {
+              "description": "File type extension.",
+              "type": "string"
+            },
+            "version_id": {
+              "type": "string"
+            }
+          },
+          "type": "object"
         }
       },
+      "description": "Describe information needed for deposit module.",
+      "type": "object",
       "required": [
-        "id"
-      ]
+        "recid",
+        "_access"
+      ],
+      "properties": {
+        "creator": {
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "description": "An entity primarily responsible for making the resource. Examples of a Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity.",
+          "properties": {
+            "email": {
+              "format": "email",
+              "description": "Contact email for the purpose of this specific record.",
+              "type": "string"
+            },
+            "contribution": {
+              "description": "Specific contribution of the person to this specific record.",
+              "type": "string"
+            },
+            "affiliations": {
+              "items": {
+                "type": "string"
+              },
+              "description": "Affiliation(s) for the purpose of this specific record.",
+              "uniqueItems": true,
+              "type": "array"
+            },
+            "name": {
+              "description": "Full name of person. Personal name format: family, given.",
+              "type": "string"
+            },
+            "ids": {
+              "items": {
+                "type": "object",
+                "properties": {
+                  "source": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "description": "List of IDs related with the person.",
+              "uniqueItems": true,
+              "type": "array"
+            }
+          },
+          "additionalProperties": false
+        },
+        "_access": {},
+        "description": {
+          "required": [
+            "value"
+          ],
+          "type": "object",
+          "description": "An account of the resource. Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource.",
+          "properties": {
+            "source": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "_deposit": {
+          "title": "Deposit",
+          "name": "_deposit",
+          "type": "object",
+          "description": "Internal deposit metadata.",
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "title": "Persistent Identifier of the deposit",
+              "name": "id",
+              "description": "Identifier of the deposit - usually the value of corresponding 'depid'-type PID.",
+              "type": "string"
+            },
+            "owners": {
+              "title": "Owners",
+              "items": [
+                {
+                  "type": "integer"
+                }
+              ],
+              "description": "Owners of the deposit (a list of user's IDs).",
+              "name": "owners",
+              "type": "integer"
+            },
+            "pid": {
+              "title": "Persistent identifier of the published record",
+              "description": "Identifier of the published record - usually the type and value of a 'recid'-type PID of the corresponding published record.",
+              "name": "pid",
+              "properties": {
+                "revision_id": {
+                  "title": "Record Revision ID",
+                  "description": "ID of the RecordMetadata revision. Used for record merging.",
+                  "type": "integer"
+                },
+                "value": {
+                  "title": "PID Value",
+                  "description": "Value of the PID, in correspondece with PID's 'pid_value' property.",
+                  "type": "string"
+                },
+                "type": {
+                  "title": "PID Type",
+                  "description": "Type of the PID, in correspondece with PID's 'pid_type' property.",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "status": {
+              "title": "Status",
+              "description": "Status of the deposit, either 'draft' or 'published'.",
+              "enum": [
+                "draft",
+                "published"
+              ],
+              "name": "status",
+              "type": "string"
+            },
+            "created_by": {
+              "title": "Creator",
+              "name": "created_by",
+              "description": "ID of user that created the deposit.",
+              "type": "integer"
+            }
+          }
+        },
+        "$schema": {
+          "type": "string"
+        },
+        "date": {
+          "format": "date-time",
+          "description": "A point or period of time associated with an event in the lifecycle of the resource. (http://www.w3.org/TR/NOTE-datetime)",
+          "type": "string"
+        },
+        "keywords": {
+          "items": {
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "description": "",
+          "type": "array"
+        },
+        "recid": {
+          "description": "Invenio record identifier (integer).",
+          "type": "number"
+        },
+        "title": {
+          "required": [
+            "title"
+          ],
+          "type": "object",
+          "description": "A name given to the resource. Typically, a Title will be a name by which the resource is formally known.",
+          "properties": {
+            "title": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "subtitle": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "_buckets": {
+          "properties": {
+            "record": {
+              "description": "Record bucket ID.",
+              "type": "string"
+            },
+            "deposit": {
+              "description": "Deposit bucket ID.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "license": {
+          "description": "A license document that applies to this content, typically indicated by URL.",
+          "type": "string"
+        },
+        "description_translations": {
+          "items": {
+            "required": [
+              "value"
+            ],
+            "type": "object",
+            "description": "An account of the resource. Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource.",
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "language": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "title_translations": {
+          "items": {
+            "required": [
+              "title"
+            ],
+            "type": "object",
+            "description": "A name given to the resource. Typically, a Title will be a name by which the resource is formally known.",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "source": {
+                "type": "string"
+              },
+              "language": {
+                "type": "string"
+              },
+              "subtitle": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "_files": {
+          "items": {
+            "description": "Describe information needed for files in records.",
+            "properties": {
+              "previewer": {
+                "description": "Identifier for previewer needed to preview this file.",
+                "type": "string"
+              },
+              "key": {
+                "type": "string"
+              },
+              "checksum": {
+                "type": "string"
+              },
+              "category": {
+                "description": "Former BibDocFile.doctype.",
+                "type": "string"
+              },
+              "bucket": {
+                "type": "string"
+              },
+              "size": {
+                "type": "integer"
+              },
+              "type": {
+                "description": "File type extension.",
+                "type": "string"
+              },
+              "version_id": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "description": "Internal listing of files attached to deposit.",
+          "name": "_files",
+          "type": "array"
+        },
+        "contributors": {
+          "items": {
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "description": "An entity responsible for making contributions to the resource. Examples of a Contributor include a person, an organization, or a service. Typically, the name of a Contributor should be used to indicate the entity.",
+            "properties": {
+              "email": {
+                "format": "email",
+                "description": "Contact email for the purpose of this specific record.",
+                "type": "string"
+              },
+              "role": {
+                "enum": [
+                  "Director",
+                  "Camera operator",
+                  "Producer",
+                  "Music by",
+                  "Editor",
+                  "Provider",
+                  "Translator",
+                  "Other"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "Full name of person. Personal name format: family, given.",
+                "type": "string"
+              },
+              "contribution": {
+                "description": "Specific contribution of the person to this specific record.",
+                "type": "string"
+              },
+              "affiliations": {
+                "items": {
+                  "type": "string"
+                },
+                "description": "Affiliation(s) for the purpose of this specific record.",
+                "uniqueItems": true,
+                "type": "array"
+              },
+              "ids": {
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "source": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "description": "List of IDs related with the person.",
+                "uniqueItems": true,
+                "type": "array"
+              }
+            },
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "videos": {
+          "items": {
+            "$reference": {
+              "type": "string"
+            }
+          },
+          "type": "array"
+        }
+      }
+    },
+    "videos": {
+      "items": {
+        "definitions": {
+          "title": {
+            "required": [
+              "title"
+            ],
+            "type": "object",
+            "description": "A name given to the resource. Typically, a Title will be a name by which the resource is formally known.",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "source": {
+                "type": "string"
+              },
+              "subtitle": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "identifier": {
+            "type": "object",
+            "description": "An unambiguous reference to the resource within a given context.",
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "language": {
+            "description": "A language of the resource.",
+            "type": "string"
+          },
+          "copyright": {
+            "description": ".",
+            "properties": {
+              "year": {
+                "format": "date-time",
+                "description": "The year during which the claimed copyright for the CreativeWork was first asserted.",
+                "type": "string"
+              },
+              "holder": {
+                "description": "The party holding the legal copyright to the record.",
+                "type": "string"
+              },
+              "url": {
+                "format": "url",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "description": {
+            "required": [
+              "value"
+            ],
+            "type": "object",
+            "description": "An account of the resource. Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource.",
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "keywords": {
+            "items": {
+              "properties": {
+                "source": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "",
+            "type": "array"
+          },
+          "creator": {
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "description": "An entity primarily responsible for making the resource. Examples of a Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity.",
+            "properties": {
+              "email": {
+                "format": "email",
+                "description": "Contact email for the purpose of this specific record.",
+                "type": "string"
+              },
+              "contribution": {
+                "description": "Specific contribution of the person to this specific record.",
+                "type": "string"
+              },
+              "affiliations": {
+                "items": {
+                  "type": "string"
+                },
+                "description": "Affiliation(s) for the purpose of this specific record.",
+                "uniqueItems": true,
+                "type": "array"
+              },
+              "name": {
+                "description": "Full name of person. Personal name format: family, given.",
+                "type": "string"
+              },
+              "ids": {
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "source": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "description": "List of IDs related with the person.",
+                "uniqueItems": true,
+                "type": "array"
+              }
+            },
+            "additionalProperties": false
+          },
+          "license": {
+            "description": "A license document that applies to this content, typically indicated by URL.",
+            "type": "string"
+          },
+          "date": {
+            "format": "date-time",
+            "description": "A point or period of time associated with an event in the lifecycle of the resource. (http://www.w3.org/TR/NOTE-datetime)",
+            "type": "string"
+          },
+          "contributor": {
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "description": "An entity responsible for making contributions to the resource. Examples of a Contributor include a person, an organization, or a service. Typically, the name of a Contributor should be used to indicate the entity.",
+            "properties": {
+              "email": {
+                "format": "email",
+                "description": "Contact email for the purpose of this specific record.",
+                "type": "string"
+              },
+              "role": {
+                "type": "string"
+              },
+              "name": {
+                "description": "Full name of person. Personal name format: family, given.",
+                "type": "string"
+              },
+              "contribution": {
+                "description": "Specific contribution of the person to this specific record.",
+                "type": "string"
+              },
+              "affiliations": {
+                "items": {
+                  "type": "string"
+                },
+                "description": "Affiliation(s) for the purpose of this specific record.",
+                "uniqueItems": true,
+                "type": "array"
+              },
+              "ids": {
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "source": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "description": "List of IDs related with the person.",
+                "uniqueItems": true,
+                "type": "array"
+              }
+            },
+            "additionalProperties": false
+          },
+          "file": {
+            "description": "A file object described using some basic subfields. (Usually to be extended).",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "checksum": {
+                "type": "string"
+              },
+              "category": {
+                "description": "Former BibDocFile.doctype.",
+                "type": "string"
+              },
+              "type": {
+                "description": "File type extension.",
+                "type": "string"
+              },
+              "size": {
+                "type": "integer"
+              },
+              "bucket": {
+                "type": "string"
+              },
+              "version_id": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "description": "Describe information needed for deposit module.",
+        "type": "object",
+        "required": [
+          "recid",
+          "_access"
+        ],
+        "properties": {
+          "creator": {
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "description": "An entity primarily responsible for making the resource. Examples of a Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity.",
+            "properties": {
+              "email": {
+                "format": "email",
+                "description": "Contact email for the purpose of this specific record.",
+                "type": "string"
+              },
+              "contribution": {
+                "description": "Specific contribution of the person to this specific record.",
+                "type": "string"
+              },
+              "affiliations": {
+                "items": {
+                  "type": "string"
+                },
+                "description": "Affiliation(s) for the purpose of this specific record.",
+                "uniqueItems": true,
+                "type": "array"
+              },
+              "name": {
+                "description": "Full name of person. Personal name format: family, given.",
+                "type": "string"
+              },
+              "ids": {
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "source": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "description": "List of IDs related with the person.",
+                "uniqueItems": true,
+                "type": "array"
+              }
+            },
+            "additionalProperties": false
+          },
+          "_access": {},
+          "description": {
+            "required": [
+              "value"
+            ],
+            "type": "object",
+            "description": "An account of the resource. Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource.",
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "_deposit": {
+            "title": "Deposit",
+            "description": "Internal deposit metadata.",
+            "type": "object",
+            "name": "_deposit",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "title": "Persistent Identifier of the deposit",
+                "description": "Identifier of the deposit - usually the value of corresponding 'depid'-type PID.",
+                "name": "id",
+                "type": "string"
+              },
+              "owners": {
+                "title": "Owners",
+                "description": "Owners of the deposit (a list of user's IDs).",
+                "items": [
+                  {
+                    "type": "integer"
+                  }
+                ],
+                "name": "owners",
+                "type": "integer"
+              },
+              "status": {
+                "title": "Status",
+                "description": "Status of the deposit, either 'draft' or 'published'.",
+                "enum": [
+                  "draft",
+                  "published"
+                ],
+                "name": "status",
+                "type": "string"
+              },
+              "pid": {
+                "title": "Persistent identifier of the published record",
+                "description": "Identifier of the published record - usually the type and value of a 'recid'-type PID of the corresponding published record.",
+                "name": "pid",
+                "properties": {
+                  "type": {
+                    "title": "PID Type",
+                    "description": "Type of the PID, in correspondece with PID's 'pid_type' property.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "title": "PID Value",
+                    "description": "Value of the PID, in correspondece with PID's 'pid_value' property.",
+                    "type": "string"
+                  },
+                  "revision_id": {
+                    "title": "Record Revision ID",
+                    "description": "ID of the RecordMetadata revision. Used for record merging.",
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              "created_by": {
+                "title": "Creator",
+                "description": "ID of user that created the deposit.",
+                "name": "created_by",
+                "type": "integer"
+              }
+            }
+          },
+          "copyright": {
+            "description": ".",
+            "properties": {
+              "year": {
+                "format": "date-time",
+                "description": "The year during which the claimed copyright for the CreativeWork was first asserted.",
+                "type": "string"
+              },
+              "holder": {
+                "description": "The party holding the legal copyright to the record.",
+                "type": "string"
+              },
+              "url": {
+                "format": "url",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "$schema": {
+            "type": "string"
+          },
+          "date": {
+            "format": "date-time",
+            "description": "A point or period of time associated with an event in the lifecycle of the resource. (http://www.w3.org/TR/NOTE-datetime)",
+            "type": "string"
+          },
+          "keywords": {
+            "items": {
+              "properties": {
+                "source": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "",
+            "type": "array"
+          },
+          "recid": {
+            "description": "Invenio record identifier (integer).",
+            "type": "number"
+          },
+          "title": {
+            "required": [
+              "title"
+            ],
+            "type": "object",
+            "description": "A name given to the resource. Typically, a Title will be a name by which the resource is formally known.",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "source": {
+                "type": "string"
+              },
+              "subtitle": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "license": {
+            "description": "A license document that applies to this content, typically indicated by URL.",
+            "type": "string"
+          },
+          "_buckets": {
+            "properties": {
+              "record": {
+                "description": "Record bucket ID.",
+                "type": "string"
+              },
+              "deposit": {
+                "description": "Deposit bucket ID.",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "contributors": {
+            "items": {
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "description": "An entity responsible for making contributions to the resource. Examples of a Contributor include a person, an organization, or a service. Typically, the name of a Contributor should be used to indicate the entity.",
+              "properties": {
+                "email": {
+                  "format": "email",
+                  "description": "Contact email for the purpose of this specific record.",
+                  "type": "string"
+                },
+                "role": {
+                  "enum": [
+                    "Director",
+                    "Camera operator",
+                    "Producer",
+                    "Music by",
+                    "Editor",
+                    "Provider",
+                    "Translator",
+                    "Other"
+                  ],
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Full name of person. Personal name format: family, given.",
+                  "type": "string"
+                },
+                "contribution": {
+                  "description": "Specific contribution of the person to this specific record.",
+                  "type": "string"
+                },
+                "affiliations": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Affiliation(s) for the purpose of this specific record.",
+                  "uniqueItems": true,
+                  "type": "array"
+                },
+                "ids": {
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "source": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "description": "List of IDs related with the person.",
+                  "uniqueItems": true,
+                  "type": "array"
+                }
+              },
+              "additionalProperties": false
+            },
+            "type": "array"
+          },
+          "description_translations": {
+            "items": {
+              "required": [
+                "value"
+              ],
+              "type": "object",
+              "description": "An account of the resource. Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource.",
+              "properties": {
+                "source": {
+                  "type": "string"
+                },
+                "language": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "type": "array"
+          },
+          "title_translations": {
+            "items": {
+              "required": [
+                "title"
+              ],
+              "type": "object",
+              "description": "A name given to the resource. Typically, a Title will be a name by which the resource is formally known.",
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "source": {
+                  "type": "string"
+                },
+                "language": {
+                  "type": "string"
+                },
+                "subtitle": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "type": "array"
+          },
+          "_files": {
+            "items": {
+              "description": "Describe information needed for files in records.",
+              "properties": {
+                "checksum": {
+                  "type": "string"
+                },
+                "quality": {
+                  "type": "string"
+                },
+                "category": {
+                  "enum": [
+                    "Master",
+                    "Slave",
+                    "Subtitle",
+                    "Other"
+                  ],
+                  "description": "Former BibDocFile.doctype.",
+                  "type": "string"
+                },
+                "bucket": {
+                  "type": "string"
+                },
+                "height": {
+                  "type": "string"
+                },
+                "previewer": {
+                  "description": "Identifier for previewer needed to preview this file.",
+                  "type": "string"
+                },
+                "width": {
+                  "type": "string"
+                },
+                "key": {
+                  "type": "string"
+                },
+                "bitrate": {
+                  "type": "string"
+                },
+                "type": {
+                  "description": "File type extension.",
+                  "type": "string"
+                },
+                "size": {
+                  "type": "integer"
+                },
+                "thumbnail": {
+                  "type": "string"
+                },
+                "version_id": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "description": ".",
+            "name": "_files",
+            "type": "array"
+          }
+        },
+        "additionalProperties": false
+      },
+      "type": "array"
     }
   },
-  "required": [
-    "_deposit"
-  ]
+  "additionalProperties": false
 }

--- a/cds_dojson/schemas/deposits/records/project_src-v1.0.0.json
+++ b/cds_dojson/schemas/deposits/records/project_src-v1.0.0.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "CDS Deposit Project Schema.",
+  "additionalProperties": false,
+  "properties": {
+    "project": {
+      "allOf": [
+        {
+          "$ref": "https://cdslabs.cern.ch/schemas/deposits/deposit-v1.0.0.json"
+        },
+        {
+          "$ref": "../../records/project-v1.0.0.json"
+        },
+        {
+          "$ref": "https://cdslabs.cern.ch/schemas/records/file-v1.0.0.json"
+        }
+      ]
+    },
+    "videos": {
+      "type": "array",
+      "items": {
+        "$ref": "video-v1.0.0.json"
+      }
+    }
+  }
+}

--- a/cds_dojson/schemas/deposits/records/video-v1.0.0.json
+++ b/cds_dojson/schemas/deposits/records/video-v1.0.0.json
@@ -1,0 +1,622 @@
+{
+  "definitions": {
+    "identifier": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "description": "An unambiguous reference to the resource within a given context."
+    },
+    "license": {
+      "type": "string",
+      "description": "A license document that applies to this content, typically indicated by URL."
+    },
+    "file": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "integer"
+        },
+        "key": {
+          "type": "string"
+        },
+        "checksum": {
+          "type": "string"
+        },
+        "category": {
+          "type": "string",
+          "description": "Former BibDocFile.doctype."
+        },
+        "type": {
+          "type": "string",
+          "description": "File type extension."
+        },
+        "bucket": {
+          "type": "string"
+        },
+        "version_id": {
+          "type": "string"
+        }
+      },
+      "description": "A file object described using some basic subfields. (Usually to be extended)."
+    },
+    "creator": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "contribution": {
+          "type": "string",
+          "description": "Specific contribution of the person to this specific record."
+        },
+        "email": {
+          "format": "email",
+          "type": "string",
+          "description": "Contact email for the purpose of this specific record."
+        },
+        "name": {
+          "type": "string",
+          "description": "Full name of person. Personal name format: family, given."
+        },
+        "affiliations": {
+          "type": "array",
+          "uniqueItems": true,
+          "description": "Affiliation(s) for the purpose of this specific record.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "description": "List of IDs related with the person.",
+          "items": {
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "description": "An entity primarily responsible for making the resource. Examples of a Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity.",
+      "required": [
+        "name"
+      ]
+    },
+    "description": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "description": "An account of the resource. Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource.",
+      "required": [
+        "value"
+      ]
+    },
+    "copyright": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "format": "url",
+          "type": "string"
+        },
+        "year": {
+          "format": "date-time",
+          "type": "string",
+          "description": "The year during which the claimed copyright for the CreativeWork was first asserted."
+        },
+        "holder": {
+          "type": "string",
+          "description": "The party holding the legal copyright to the record."
+        }
+      },
+      "description": "."
+    },
+    "keywords": {
+      "type": "array",
+      "description": "",
+      "items": {
+        "properties": {
+          "source": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "title": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "subtitle": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        }
+      },
+      "description": "A name given to the resource. Typically, a Title will be a name by which the resource is formally known.",
+      "required": [
+        "title"
+      ]
+    },
+    "date": {
+      "format": "date-time",
+      "type": "string",
+      "description": "A point or period of time associated with an event in the lifecycle of the resource. (http://www.w3.org/TR/NOTE-datetime)"
+    },
+    "contributor": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "contribution": {
+          "type": "string",
+          "description": "Specific contribution of the person to this specific record."
+        },
+        "name": {
+          "type": "string",
+          "description": "Full name of person. Personal name format: family, given."
+        },
+        "role": {
+          "type": "string"
+        },
+        "email": {
+          "format": "email",
+          "type": "string",
+          "description": "Contact email for the purpose of this specific record."
+        },
+        "ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "description": "List of IDs related with the person.",
+          "items": {
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "affiliations": {
+          "type": "array",
+          "uniqueItems": true,
+          "description": "Affiliation(s) for the purpose of this specific record.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "An entity responsible for making contributions to the resource. Examples of a Contributor include a person, an organization, or a service. Typically, the name of a Contributor should be used to indicate the entity.",
+      "required": [
+        "name"
+      ]
+    },
+    "language": {
+      "type": "string",
+      "description": "A language of the resource."
+    }
+  },
+  "description": "Describe information needed for deposit module.",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "recid",
+    "_access"
+  ],
+  "properties": {
+    "copyright": {
+      "type": "object",
+      "description": ".",
+      "properties": {
+        "url": {
+          "format": "url",
+          "type": "string"
+        },
+        "year": {
+          "format": "date-time",
+          "type": "string",
+          "description": "The year during which the claimed copyright for the CreativeWork was first asserted."
+        },
+        "holder": {
+          "type": "string",
+          "description": "The party holding the legal copyright to the record."
+        }
+      }
+    },
+    "description": {
+      "additionalProperties": false,
+      "type": "object",
+      "description": "An account of the resource. Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "title": {
+      "additionalProperties": false,
+      "type": "object",
+      "description": "A name given to the resource. Typically, a Title will be a name by which the resource is formally known.",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "subtitle": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "title"
+      ]
+    },
+    "keywords": {
+      "type": "array",
+      "description": "",
+      "items": {
+        "properties": {
+          "source": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "description_translations": {
+      "type": "array",
+      "items": {
+        "additionalProperties": false,
+        "type": "object",
+        "description": "An account of the resource. Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource.",
+        "properties": {
+          "source": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "language": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "value"
+        ]
+      }
+    },
+    "date": {
+      "format": "date-time",
+      "type": "string",
+      "description": "A point or period of time associated with an event in the lifecycle of the resource. (http://www.w3.org/TR/NOTE-datetime)"
+    },
+    "_access": {},
+    "_deposit": {
+      "name": "_deposit",
+      "title": "Deposit",
+      "description": "Internal deposit metadata.",
+      "required": [
+        "id"
+      ],
+      "type": "object",
+      "properties": {
+        "pid": {
+          "name": "pid",
+          "title": "Persistent identifier of the published record",
+          "type": "object",
+          "description": "Identifier of the published record - usually the type and value of a 'recid'-type PID of the corresponding published record.",
+          "properties": {
+            "revision_id": {
+              "title": "Record Revision ID",
+              "type": "integer",
+              "description": "ID of the RecordMetadata revision. Used for record merging."
+            },
+            "type": {
+              "title": "PID Type",
+              "type": "string",
+              "description": "Type of the PID, in correspondece with PID's 'pid_type' property."
+            },
+            "value": {
+              "title": "PID Value",
+              "type": "string",
+              "description": "Value of the PID, in correspondece with PID's 'pid_value' property."
+            }
+          }
+        },
+        "id": {
+          "name": "id",
+          "title": "Persistent Identifier of the deposit",
+          "type": "string",
+          "description": "Identifier of the deposit - usually the value of corresponding 'depid'-type PID."
+        },
+        "owners": {
+          "name": "owners",
+          "title": "Owners",
+          "type": "integer",
+          "description": "Owners of the deposit (a list of user's IDs).",
+          "items": [
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "status": {
+          "name": "status",
+          "title": "Status",
+          "type": "string",
+          "description": "Status of the deposit, either 'draft' or 'published'.",
+          "enum": [
+            "draft",
+            "published"
+          ]
+        },
+        "created_by": {
+          "name": "created_by",
+          "title": "Creator",
+          "type": "integer",
+          "description": "ID of user that created the deposit."
+        }
+      }
+    },
+    "$schema": {
+      "type": "string"
+    },
+    "license": {
+      "type": "string",
+      "description": "A license document that applies to this content, typically indicated by URL."
+    },
+    "contributors": {
+      "type": "array",
+      "items": {
+        "additionalProperties": false,
+        "type": "object",
+        "description": "An entity responsible for making contributions to the resource. Examples of a Contributor include a person, an organization, or a service. Typically, the name of a Contributor should be used to indicate the entity.",
+        "properties": {
+          "contribution": {
+            "type": "string",
+            "description": "Specific contribution of the person to this specific record."
+          },
+          "name": {
+            "type": "string",
+            "description": "Full name of person. Personal name format: family, given."
+          },
+          "affiliations": {
+            "type": "array",
+            "uniqueItems": true,
+            "description": "Affiliation(s) for the purpose of this specific record.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "Director",
+              "Camera operator",
+              "Producer",
+              "Music by",
+              "Editor",
+              "Provider",
+              "Translator",
+              "Other"
+            ]
+          },
+          "email": {
+            "format": "email",
+            "type": "string",
+            "description": "Contact email for the purpose of this specific record."
+          },
+          "ids": {
+            "type": "array",
+            "uniqueItems": true,
+            "description": "List of IDs related with the person.",
+            "items": {
+              "additionalProperties": false,
+              "type": "object",
+              "properties": {
+                "source": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "name"
+        ]
+      }
+    },
+    "_files": {
+      "name": "_files",
+      "type": "array",
+      "description": ".",
+      "items": {
+        "type": "object",
+        "description": "Describe information needed for files in records.",
+        "properties": {
+          "width": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "category": {
+            "type": "string",
+            "enum": [
+              "Master",
+              "Slave",
+              "Subtitle",
+              "Other"
+            ],
+            "description": "Former BibDocFile.doctype."
+          },
+          "bucket": {
+            "type": "string"
+          },
+          "height": {
+            "type": "string"
+          },
+          "thumbnail": {
+            "type": "string"
+          },
+          "bitrate": {
+            "type": "string"
+          },
+          "checksum": {
+            "type": "string"
+          },
+          "previewer": {
+            "type": "string",
+            "description": "Identifier for previewer needed to preview this file."
+          },
+          "type": {
+            "type": "string",
+            "description": "File type extension."
+          },
+          "quality": {
+            "type": "string"
+          },
+          "version_id": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "creator": {
+      "additionalProperties": false,
+      "type": "object",
+      "description": "An entity primarily responsible for making the resource. Examples of a Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity.",
+      "properties": {
+        "contribution": {
+          "type": "string",
+          "description": "Specific contribution of the person to this specific record."
+        },
+        "email": {
+          "format": "email",
+          "type": "string",
+          "description": "Contact email for the purpose of this specific record."
+        },
+        "name": {
+          "type": "string",
+          "description": "Full name of person. Personal name format: family, given."
+        },
+        "affiliations": {
+          "type": "array",
+          "uniqueItems": true,
+          "description": "Affiliation(s) for the purpose of this specific record.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "description": "List of IDs related with the person.",
+          "items": {
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "_buckets": {
+      "type": "object",
+      "properties": {
+        "deposit": {
+          "type": "string",
+          "description": "Deposit bucket ID."
+        },
+        "record": {
+          "type": "string",
+          "description": "Record bucket ID."
+        }
+      }
+    },
+    "recid": {
+      "type": "number",
+      "description": "Invenio record identifier (integer)."
+    },
+    "title_translations": {
+      "type": "array",
+      "items": {
+        "additionalProperties": false,
+        "type": "object",
+        "description": "A name given to the resource. Typically, a Title will be a name by which the resource is formally known.",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "subtitle": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "language": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ]
+      }
+    }
+  }
+}

--- a/cds_dojson/schemas/deposits/records/video_src-v1.0.0.json
+++ b/cds_dojson/schemas/deposits/records/video_src-v1.0.0.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "CDS Deposit Video Schema.",
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "$ref": "https://cdslabs.cern.ch/schemas/deposits/deposit-v1.0.0.json"
+    },
+    {
+      "$ref": "../../records/video-v1.0.0.json"
+    },
+    {
+      "$ref": "https://cdslabs.cern.ch/schemas/records/file-v1.0.0.json"
+    }
+  ]
+}

--- a/cds_dojson/schemas/records/base-v1.0.0.json
+++ b/cds_dojson/schemas/records/base-v1.0.0.json
@@ -219,23 +219,27 @@
   "type": "object",
   "properties": {
     "$schema": {
-      "type": "object",
-      "properties": {
-        "$ref": {
-            "description": "URL to the referenced resource",
-            "format": "url",
-            "type": "string"
-        }
-      },
-      "required": [
-        "$ref"
-       ]
+      "type": "string"
     },
     "recid": {
       "description": "Invenio record identifier (integer).",
       "type": "number"
     },
-    "_access": {}
+    "_access": {},
+    "_deposit": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "created_by": {
+          "type": "integer"
+        },
+        "owners": {
+          "type": "integer"
+        }
+      }
+    }
   },
   "required": ["recid", "_access"]
 }

--- a/cds_dojson/schemas/records/project-v1.0.0.json
+++ b/cds_dojson/schemas/records/project-v1.0.0.json
@@ -1,21 +1,517 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "CDS Base Record Schema v1.0.0",
   "type": "object",
-  "title": "Deposit schema.",
-  "description": "Describe information needed for deposit module.",
   "properties": {
-    "basic_info": {
-      "type": "object",
+    "creator": {
       "properties": {
+        "affiliations": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "description": "Affiliation(s) for the purpose of this specific record."
+        },
+        "ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "description": "List of IDs related with the person."
+        },
         "name": {
           "type": "string",
-          "title": "Analysis Name"
+          "description": "Full name of person. Personal name format: family, given."
         },
-        "description": {
+        "email": {
           "type": "string",
-          "title": "Description"
+          "description": "Contact email for the purpose of this specific record.",
+          "format": "email"
+        },
+        "contribution": {
+          "type": "string",
+          "description": "Specific contribution of the person to this specific record."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "An entity primarily responsible for making the resource. Examples of a Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity.",
+      "required": [
+        "name"
+      ]
+    },
+    "_access": {},
+    "description": {
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "An account of the resource. Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource.",
+      "required": [
+        "value"
+      ]
+    },
+    "_files": {
+      "items": {
+        "type": "object",
+        "description": "A file object described using some basic subfields. (Usually to be extended).",
+        "properties": {
+          "checksum": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "description": "File type extension."
+          },
+          "size": {
+            "type": "integer"
+          },
+          "category": {
+            "type": "string",
+            "description": "Former BibDocFile.doctype."
+          },
+          "bucket": {
+            "type": "string"
+          },
+          "version_id": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          }
+        }
+      },
+      "type": "array"
+    },
+    "contributors": {
+      "items": {
+        "properties": {
+          "affiliations": {
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true,
+            "type": "array",
+            "description": "Affiliation(s) for the purpose of this specific record."
+          },
+          "role": {
+            "enum": [
+              "Director",
+              "Camera operator",
+              "Producer",
+              "Music by",
+              "Editor",
+              "Provider",
+              "Translator",
+              "Other"
+            ],
+            "type": "string"
+          },
+          "ids": {
+            "items": {
+              "additionalProperties": false,
+              "type": "object",
+              "properties": {
+                "source": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
+              }
+            },
+            "uniqueItems": true,
+            "type": "array",
+            "description": "List of IDs related with the person."
+          },
+          "name": {
+            "type": "string",
+            "description": "Full name of person. Personal name format: family, given."
+          },
+          "email": {
+            "type": "string",
+            "description": "Contact email for the purpose of this specific record.",
+            "format": "email"
+          },
+          "contribution": {
+            "type": "string",
+            "description": "Specific contribution of the person to this specific record."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "description": "An entity responsible for making contributions to the resource. Examples of a Contributor include a person, an organization, or a service. Typically, the name of a Contributor should be used to indicate the entity.",
+        "required": [
+          "name"
+        ]
+      },
+      "type": "array"
+    },
+    "$schema": {
+      "type": "string"
+    },
+    "recid": {
+      "type": "number",
+      "description": "Invenio record identifier (integer)."
+    },
+    "title": {
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "subtitle": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "A name given to the resource. Typically, a Title will be a name by which the resource is formally known.",
+      "required": [
+        "title"
+      ]
+    },
+    "keywords": {
+      "type": "array",
+      "items": {
+        "properties": {
+          "source": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "description": ""
+    },
+    "videos": {
+      "items": {
+        "$reference": {
+          "type": "string"
+        }
+      },
+      "type": "array"
+    },
+    "description_translations": {
+      "items": {
+        "properties": {
+          "source": {
+            "type": "string"
+          },
+          "language": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "description": "An account of the resource. Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource.",
+        "required": [
+          "value"
+        ]
+      },
+      "type": "array"
+    },
+    "license": {
+      "type": "string",
+      "description": "A license document that applies to this content, typically indicated by URL."
+    },
+    "_deposit": {
+      "type": "object",
+      "properties": {
+        "owners": {
+          "type": "integer"
+        },
+        "created_by": {
+          "type": "integer"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "title_translations": {
+      "items": {
+        "properties": {
+          "source": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "language": {
+            "type": "string"
+          },
+          "subtitle": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "description": "A name given to the resource. Typically, a Title will be a name by which the resource is formally known.",
+        "required": [
+          "title"
+        ]
+      },
+      "type": "array"
+    },
+    "date": {
+      "type": "string",
+      "description": "A point or period of time associated with an event in the lifecycle of the resource. (http://www.w3.org/TR/NOTE-datetime)",
+      "format": "date-time"
+    }
+  },
+  "definitions": {
+    "creator": {
+      "properties": {
+        "affiliations": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "description": "Affiliation(s) for the purpose of this specific record."
+        },
+        "ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "description": "List of IDs related with the person."
+        },
+        "name": {
+          "type": "string",
+          "description": "Full name of person. Personal name format: family, given."
+        },
+        "email": {
+          "type": "string",
+          "description": "Contact email for the purpose of this specific record.",
+          "format": "email"
+        },
+        "contribution": {
+          "type": "string",
+          "description": "Specific contribution of the person to this specific record."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "An entity primarily responsible for making the resource. Examples of a Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity.",
+      "required": [
+        "name"
+      ]
+    },
+    "title": {
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "subtitle": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "A name given to the resource. Typically, a Title will be a name by which the resource is formally known.",
+      "required": [
+        "title"
+      ]
+    },
+    "keywords": {
+      "type": "array",
+      "items": {
+        "properties": {
+          "source": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "description": ""
+    },
+    "description": {
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "An account of the resource. Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource.",
+      "required": [
+        "value"
+      ]
+    },
+    "language": {
+      "type": "string",
+      "description": "A language of the resource."
+    },
+    "identifier": {
+      "additionalProperties": false,
+      "type": "object",
+      "description": "An unambiguous reference to the resource within a given context.",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "contributor": {
+      "properties": {
+        "affiliations": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "description": "Affiliation(s) for the purpose of this specific record."
+        },
+        "role": {
+          "type": "string"
+        },
+        "ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "description": "List of IDs related with the person."
+        },
+        "name": {
+          "type": "string",
+          "description": "Full name of person. Personal name format: family, given."
+        },
+        "email": {
+          "type": "string",
+          "description": "Contact email for the purpose of this specific record.",
+          "format": "email"
+        },
+        "contribution": {
+          "type": "string",
+          "description": "Specific contribution of the person to this specific record."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "An entity responsible for making contributions to the resource. Examples of a Contributor include a person, an organization, or a service. Typically, the name of a Contributor should be used to indicate the entity.",
+      "required": [
+        "name"
+      ]
+    },
+    "date": {
+      "type": "string",
+      "description": "A point or period of time associated with an event in the lifecycle of the resource. (http://www.w3.org/TR/NOTE-datetime)",
+      "format": "date-time"
+    },
+    "copyright": {
+      "type": "object",
+      "description": ".",
+      "properties": {
+        "holder": {
+          "type": "string",
+          "description": "The party holding the legal copyright to the record."
+        },
+        "year": {
+          "type": "string",
+          "description": "The year during which the claimed copyright for the CreativeWork was first asserted.",
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "format": "url"
+        }
+      }
+    },
+    "license": {
+      "type": "string",
+      "description": "A license document that applies to this content, typically indicated by URL."
+    },
+    "file": {
+      "type": "object",
+      "description": "A file object described using some basic subfields. (Usually to be extended).",
+      "properties": {
+        "checksum": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "description": "File type extension."
+        },
+        "size": {
+          "type": "integer"
+        },
+        "category": {
+          "type": "string",
+          "description": "Former BibDocFile.doctype."
+        },
+        "bucket": {
+          "type": "string"
+        },
+        "version_id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
         }
       }
     }
-  }
+  },
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "required": [
+    "recid",
+    "_access"
+  ]
 }

--- a/cds_dojson/schemas/records/project_src-v1.0.0.json
+++ b/cds_dojson/schemas/records/project_src-v1.0.0.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "CDS Project Record Schema v1.0.0",
+  "allOf": [
+    { "$ref": "base-v1.0.0.json" },
+    {"properties":
+      {
+        "title": { "$ref": "base-v1.0.0.json#/definitions/title" },
+        "title_translations": {
+          "type": "array",
+          "items": {
+            "allOf": [
+              { "$ref": "base-v1.0.0.json#/definitions/title" },
+              {
+                "properties": {
+                  "language": {
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "keywords": { "$ref": "base-v1.0.0.json#/definitions/keywords" },
+        "description": { "$ref": "base-v1.0.0.json#/definitions/description" },
+        "description_translations": {
+          "type": "array",
+          "items": {
+            "allOf": [
+              { "$ref": "base-v1.0.0.json#/definitions/description" },
+              {
+                "properties": {
+                  "language": {
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "creator": { "$ref": "base-v1.0.0.json#/definitions/creator" },
+        "contributors": {
+          "type": "array",
+          "items": {
+            "allOf": [
+              {"$ref": "base-v1.0.0.json#/definitions/contributor"},
+              {
+                "properties": {
+                  "role": {
+                    "type": "string",
+                    "enum": [
+                      "Director",
+                      "Camera operator",
+                      "Producer",
+                      "Music by",
+                      "Editor",
+                      "Provider",
+                      "Translator",
+                      "Other"
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "date": { "$ref": "base-v1.0.0.json#/definitions/date" },
+        "license": { "$ref": "base-v1.0.0.json#/definitions/license" },
+        "_files": {
+            "type": "array",
+            "items": {
+              "$ref": "base-v1.0.0.json#/definitions/file"
+            }
+        },
+        "videos": {
+          "type": "array",
+          "items": {
+            "$reference": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/cds_dojson/schemas/records/video-v1.0.0.json
+++ b/cds_dojson/schemas/records/video-v1.0.0.json
@@ -1,116 +1,550 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "CDS Video Record Schema v1.0.0",
-  "allOf": [
-    { "$ref": "base-v1.0.0.json" },
-    {
+  "properties": {
+    "creator": {
+      "additionalProperties": false,
+      "type": "object",
       "properties": {
-        "title": { "$ref": "base-v1.0.0.json/definitions/title" },
-        "title_translations": {
+        "ids": {
           "type": "array",
+          "uniqueItems": true,
+          "description": "List of IDs related with the person.",
           "items": {
-            "allOf": [
-              { "$ref": "base-v1.0.0.json/definitions/title" },
-              {
-                "properties": {
-                  "language": {
-                    "type": "string"
-                  }
-                }
-              }
-            ]
-          }
-        },
-        "keywords": { "$ref": "base-v1.0.0.json/definitions/keywords" },
-        "description": { "$ref": "base-v1.0.0.json/definitions/description" },
-        "description_translations": {
-          "type": "array",
-          "items": {
-            "allOf": [
-              { "$ref": "base-v1.0.0.json/definitions/description" },
-              {
-                "properties": {
-                  "language": {
-                    "type": "string"
-                  }
-                }
-              }
-            ]
-          }
-        },
-        "creator": { "$ref": "base-v1.0.0.json/definitions/creator" },
-        "contributors": {
-          "type": "array",
-          "items": {
-            "allOff": [
-              {"$ref": "base-v1.0.0.json/definitions/contributor"},
-              {
-                "properties": {
-                  "role": {
-                    "type": "string",
-                    "enum": [
-                      "Director",
-                      "Camera operator",
-                      "Producer",
-                      "Music by",
-                      "Editor",
-                      "Provider",
-                      "Translator",
-                      "Other"
-                    ]
-                  }
-                }
-              }
-            ]
-          }
-        },
-        "date": { "$ref": "base-v1.0.0.json/definitions/date" },
-        "copyright": { "$ref": "base-v1.0.0.json/definitions/copyright" },
-        "license": { "$ref": "base-v1.0.0.json/definitions/license" },
-        "_files": {
-          "description": ".",
-          "type": "array",
-          "items":{
-            "anyOf": [
-              {
-                "allOf": [
-                  { "$ref": "base-v1.0.0.json/definitions/file" },
-                  {
-                    "properties": {
-                      "category": {
-                        "enum": [
-                          "Master",
-                          "Slave"
-                        ]
-                      },
-                      "bitrate": {"type": "string"},
-                      "quality": {"type": "string"},
-                      "height": {"type": "string"},
-                      "width": {"type": "string"},
-                      "thumbnail": {"type": "string"}
-                    }
-                  }
-                ]
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string"
               },
-              {
-                "allOf": [
-                  { "$ref": "base-v1.0.0.json/definitions/file" },
-                  {
-                    "properties": {
-                      "category": {
-                        "enum": [
-                          "Subtitle",
-                          "Other"
-                        ]
-                      }
-                    }
-                  }
-                ]
+              "value": {
+                "type": "string"
               }
-            ]
+            }
+          }
+        },
+        "email": {
+          "type": "string",
+          "description": "Contact email for the purpose of this specific record.",
+          "format": "email"
+        },
+        "contribution": {
+          "type": "string",
+          "description": "Specific contribution of the person to this specific record."
+        },
+        "affiliations": {
+          "type": "array",
+          "uniqueItems": true,
+          "description": "Affiliation(s) for the purpose of this specific record.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "type": "string",
+          "description": "Full name of person. Personal name format: family, given."
+        }
+      },
+      "description": "An entity primarily responsible for making the resource. Examples of a Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity.",
+      "required": [
+        "name"
+      ]
+    },
+    "copyright": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "url"
+        },
+        "year": {
+          "type": "string",
+          "description": "The year during which the claimed copyright for the CreativeWork was first asserted.",
+          "format": "date-time"
+        },
+        "holder": {
+          "type": "string",
+          "description": "The party holding the legal copyright to the record."
+        }
+      },
+      "description": "."
+    },
+    "description": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "description": "An account of the resource. Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource.",
+      "required": [
+        "value"
+      ]
+    },
+    "contributors": {
+      "type": "array",
+      "items": {
+        "additionalProperties": false,
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "Contact email for the purpose of this specific record.",
+            "format": "email"
+          },
+          "affiliations": {
+            "type": "array",
+            "uniqueItems": true,
+            "description": "Affiliation(s) for the purpose of this specific record.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "contribution": {
+            "type": "string",
+            "description": "Specific contribution of the person to this specific record."
+          },
+          "role": {
+            "enum": [
+              "Director",
+              "Camera operator",
+              "Producer",
+              "Music by",
+              "Editor",
+              "Provider",
+              "Translator",
+              "Other"
+            ],
+            "type": "string"
+          },
+          "ids": {
+            "type": "array",
+            "uniqueItems": true,
+            "description": "List of IDs related with the person.",
+            "items": {
+              "additionalProperties": false,
+              "type": "object",
+              "properties": {
+                "source": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "name": {
+            "type": "string",
+            "description": "Full name of person. Personal name format: family, given."
+          }
+        },
+        "description": "An entity responsible for making contributions to the resource. Examples of a Contributor include a person, an organization, or a service. Typically, the name of a Contributor should be used to indicate the entity.",
+        "required": [
+          "name"
+        ]
+      }
+    },
+    "_files": {
+      "type": "array",
+      "description": ".",
+      "items": {
+        "type": "object",
+        "properties": {
+          "width": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          },
+          "bitrate": {
+            "type": "string"
+          },
+          "category": {
+            "enum": [
+              "Master",
+              "Slave",
+              "Subtitle",
+              "Other"
+            ],
+            "type": "string",
+            "description": "Former BibDocFile.doctype."
+          },
+          "thumbnail": {
+            "type": "string"
+          },
+          "checksum": {
+            "type": "string"
+          },
+          "version_id": {
+            "type": "string"
+          },
+          "height": {
+            "type": "string"
+          },
+          "bucket": {
+            "type": "string"
+          },
+          "quality": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "description": "File type extension."
+          },
+          "size": {
+            "type": "integer"
+          }
+        },
+        "description": "A file object described using some basic subfields. (Usually to be extended)."
+      }
+    },
+    "title_translations": {
+      "type": "array",
+      "items": {
+        "additionalProperties": false,
+        "type": "object",
+        "properties": {
+          "source": {
+            "type": "string"
+          },
+          "subtitle": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "language": {
+            "type": "string"
+          }
+        },
+        "description": "A name given to the resource. Typically, a Title will be a name by which the resource is formally known.",
+        "required": [
+          "title"
+        ]
+      }
+    },
+    "license": {
+      "type": "string",
+      "description": "A license document that applies to this content, typically indicated by URL."
+    },
+    "description_translations": {
+      "type": "array",
+      "items": {
+        "additionalProperties": false,
+        "type": "object",
+        "properties": {
+          "source": {
+            "type": "string"
+          },
+          "language": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "description": "An account of the resource. Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource.",
+        "required": [
+          "value"
+        ]
+      }
+    },
+    "_access": {},
+    "date": {
+      "type": "string",
+      "description": "A point or period of time associated with an event in the lifecycle of the resource. (http://www.w3.org/TR/NOTE-datetime)",
+      "format": "date-time"
+    },
+    "recid": {
+      "type": "number",
+      "description": "Invenio record identifier (integer)."
+    },
+    "_deposit": {
+      "type": "object",
+      "properties": {
+        "created_by": {
+          "type": "integer"
+        },
+        "owners": {
+          "type": "integer"
+        },
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "keywords": {
+      "type": "array",
+      "description": "",
+      "items": {
+        "properties": {
+          "source": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
           }
         }
       }
+    },
+    "title": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "subtitle": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "description": "A name given to the resource. Typically, a Title will be a name by which the resource is formally known.",
+      "required": [
+        "title"
+      ]
+    },
+    "$schema": {
+      "type": "string"
     }
-  ]
+  },
+  "required": [
+    "recid",
+    "_access"
+  ],
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "CDS Base Record Schema v1.0.0",
+  "definitions": {
+    "creator": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "description": "List of IDs related with the person.",
+          "items": {
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "email": {
+          "type": "string",
+          "description": "Contact email for the purpose of this specific record.",
+          "format": "email"
+        },
+        "contribution": {
+          "type": "string",
+          "description": "Specific contribution of the person to this specific record."
+        },
+        "affiliations": {
+          "type": "array",
+          "uniqueItems": true,
+          "description": "Affiliation(s) for the purpose of this specific record.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "type": "string",
+          "description": "Full name of person. Personal name format: family, given."
+        }
+      },
+      "description": "An entity primarily responsible for making the resource. Examples of a Creator include a person, an organization, or a service. Typically, the name of a Creator should be used to indicate the entity.",
+      "required": [
+        "name"
+      ]
+    },
+    "license": {
+      "type": "string",
+      "description": "A license document that applies to this content, typically indicated by URL."
+    },
+    "identifier": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "description": "An unambiguous reference to the resource within a given context."
+    },
+    "keywords": {
+      "type": "array",
+      "description": "",
+      "items": {
+        "properties": {
+          "source": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "description": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "description": "An account of the resource. Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource.",
+      "required": [
+        "value"
+      ]
+    },
+    "contributor": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "description": "Contact email for the purpose of this specific record.",
+          "format": "email"
+        },
+        "affiliations": {
+          "type": "array",
+          "uniqueItems": true,
+          "description": "Affiliation(s) for the purpose of this specific record.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "contribution": {
+          "type": "string",
+          "description": "Specific contribution of the person to this specific record."
+        },
+        "role": {
+          "type": "string"
+        },
+        "ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "description": "List of IDs related with the person.",
+          "items": {
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "name": {
+          "type": "string",
+          "description": "Full name of person. Personal name format: family, given."
+        }
+      },
+      "description": "An entity responsible for making contributions to the resource. Examples of a Contributor include a person, an organization, or a service. Typically, the name of a Contributor should be used to indicate the entity.",
+      "required": [
+        "name"
+      ]
+    },
+    "file": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "category": {
+          "type": "string",
+          "description": "Former BibDocFile.doctype."
+        },
+        "bucket": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "description": "File type extension."
+        },
+        "version_id": {
+          "type": "string"
+        },
+        "checksum": {
+          "type": "string"
+        },
+        "size": {
+          "type": "integer"
+        }
+      },
+      "description": "A file object described using some basic subfields. (Usually to be extended)."
+    },
+    "language": {
+      "type": "string",
+      "description": "A language of the resource."
+    },
+    "date": {
+      "type": "string",
+      "description": "A point or period of time associated with an event in the lifecycle of the resource. (http://www.w3.org/TR/NOTE-datetime)",
+      "format": "date-time"
+    },
+    "title": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "subtitle": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "description": "A name given to the resource. Typically, a Title will be a name by which the resource is formally known.",
+      "required": [
+        "title"
+      ]
+    },
+    "copyright": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "url"
+        },
+        "year": {
+          "type": "string",
+          "description": "The year during which the claimed copyright for the CreativeWork was first asserted.",
+          "format": "date-time"
+        },
+        "holder": {
+          "type": "string",
+          "description": "The party holding the legal copyright to the record."
+        }
+      },
+      "description": "."
+    }
+  },
+  "type": "object"
 }

--- a/cds_dojson/schemas/records/video_src-v1.0.0.json
+++ b/cds_dojson/schemas/records/video_src-v1.0.0.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "CDS Video Record Schema v1.0.0",
+  "allOf": [
+    { "$ref": "base-v1.0.0.json" },
+    {
+      "properties": {
+        "title": { "$ref": "base-v1.0.0.json#/definitions/title" },
+        "title_translations": {
+          "type": "array",
+          "items": {
+            "allOf": [
+              { "$ref": "base-v1.0.0.json#/definitions/title" },
+              {
+                "properties": {
+                  "language": {
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "keywords": { "$ref": "base-v1.0.0.json#/definitions/keywords" },
+        "description": { "$ref": "base-v1.0.0.json#/definitions/description" },
+        "description_translations": {
+          "type": "array",
+          "items": {
+            "allOf": [
+              { "$ref": "base-v1.0.0.json#/definitions/description" },
+              {
+                "properties": {
+                  "language": {
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "creator": { "$ref": "base-v1.0.0.json#/definitions/creator" },
+        "contributors": {
+          "type": "array",
+          "items": {
+            "allOf": [
+              {"$ref": "base-v1.0.0.json#/definitions/contributor"},
+              {
+                "properties": {
+                  "role": {
+                    "type": "string",
+                    "enum": [
+                      "Director",
+                      "Camera operator",
+                      "Producer",
+                      "Music by",
+                      "Editor",
+                      "Provider",
+                      "Translator",
+                      "Other"
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "date": { "$ref": "base-v1.0.0.json#/definitions/date" },
+        "copyright": { "$ref": "base-v1.0.0.json#/definitions/copyright" },
+        "license": { "$ref": "base-v1.0.0.json#/definitions/license" },
+        "_files": {
+          "description": ".",
+          "type": "array",
+          "items":{
+            "allOf": [
+              { "$ref": "base-v1.0.0.json#/definitions/file" },
+              {
+                "properties": {
+                  "category": {
+                  "enum": [
+                      "Master",
+                      "Slave",
+                      "Subtitle",
+                      "Other"
+                  ]
+                  },
+                  "bitrate": {"type": "string"},
+                  "quality": {"type": "string"},
+                  "height": {"type": "string"},
+                  "width": {"type": "string"},
+                  "thumbnail": {"type": "string"}
+              }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/cds_dojson/schemas/tranform.py
+++ b/cds_dojson/schemas/tranform.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CERN Document Server.
+# Copyright (C) 2016 CERN.
+#
+# CERN Document Server is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CERN Document Server is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with CERN Document Server; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+import copy
+import jsonschema
+import six
+
+from jsonresolver import JSONResolver
+from jsonresolver.contrib.jsonschema import ref_resolver_factory
+
+
+def compile_schema(schema, base_uri='', ref_resolver=None, in_place=False):
+    """Resolve references in schema.
+
+    It is assumed that schemas have already been validated for backward
+    compatibility before transforming.
+
+    :param schema: Schema that is currently processed.
+    :param base_uri: URI of the currently processed schema.
+                     If not provided it will use default.
+    :param ref_resolver: Resolver used to retrieve referenced schemas.
+                         If not provided it will use default.
+    :param in_place: If set to False it will not modify given schema.
+                          Modified copy of the schema will be returned.
+    """
+    if not in_place:
+        schema = copy.deepcopy(schema)
+
+    if ref_resolver is None:
+        ref_resolver = jsonschema.RefResolver(base_uri=base_uri, referrer=schema)
+
+    json_resolver = JSONResolver()
+    resolver_cls = ref_resolver_factory(json_resolver)
+    ref_refolver = resolver_cls.from_schema(schema)
+
+    return _compile_all_of(_resolve_references_sub(schema, ref_resolver))
+
+
+def _resolve_references_sub(schema, ref_resolver):
+    """Go through the schema and resolve references.
+
+    :param schema: Schema that is currently processed.
+    :param ref_resolver: Resolver used to retrieve referenced schemas.
+    """
+    if isinstance(schema, dict):
+        for key, json_value in six.iteritems(schema):
+            if isinstance(json_value, dict) and '$ref' in json_value:
+                    ref = json_value.pop('$ref', None)
+                    schema[key] = ref_resolver.resolve(ref)[1]
+            _resolve_references_sub(schema[key], ref_resolver)
+
+    elif isinstance(schema, list):
+        for i, schema_part in enumerate(schema):
+            if '$ref' in schema_part:
+                ref = schema_part.pop('$ref', None)
+                schema[i] = ref_resolver.resolve(ref)[1]
+            _resolve_references_sub(schema_part, ref_resolver)
+
+    return schema
+
+
+def _compile_all_of(schema):
+    """Go through the schema an compile the ``allOf`` rules."""
+    if isinstance(schema, dict):
+        if 'allOf' in schema:
+            all_of = schema.pop('allOf')
+            schema = merge_dicts(schema, *all_of)
+        for key, value in six.iteritems(schema):
+            schema[key] = _compile_all_of(value)
+    elif isinstance(schema, list):
+        for i, value in enumerate(schema):
+            schema[i] = _compile_all_of(value)
+    return schema
+
+
+def merge_dicts(base, *others):
+    """Merge the 'second' multiple-dictionary into the 'first' one."""
+    new = copy.deepcopy(base)
+    for other in others:
+        for k, v in other.items():
+            if isinstance(v, dict) and v:
+                ret = merge_dicts(new.get(k, dict()), v)
+                new[k] = ret
+            else:
+                new[k] = other[k]
+    return new

--- a/setup.py
+++ b/setup.py
@@ -136,6 +136,9 @@ setup(
             'video = cds_dojson.to_marc21.fields.video'
         ],
         # DoJSON entry points
+        'console_scripts': [
+            'cds-dojson=cds_dojson.cli:cli',
+        ],
         'dojson.cli.rule': [
             'cds_marc21 = cds_dojson.marc21:marc21',
             'cds_to_marc21 = cds_dojson.to_marc21:to_marc21'

--- a/tests/test_cds_dojson_video.py
+++ b/tests/test_cds_dojson_video.py
@@ -34,7 +34,7 @@ from cds_dojson.marc21.models.video import model as marc21
 from cds_dojson.matcher import matcher
 from cds_dojson.to_marc21.models.video import model as to_marc21
 
-from testutils import mock_path_to_url, mock_get_schema, json_resolver
+from testutils import mock_path_to_url, json_resolver
 
 
 CDS_VIDEO_PROJECT = """
@@ -371,8 +371,6 @@ def test_identity_check(app):
 
 @mock.patch('invenio_jsonschemas.ext.InvenioJSONSchemasState.path_to_url',
             mock_path_to_url)
-@mock.patch('invenio_jsonschemas.ext.InvenioJSONSchemasState.get_schema',
-            mock_get_schema)
 def test_jsonschema(app):
     """Test jsonschema."""
     with app.app_context():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CERN Document Server.
+# Copyright (C) 2016 CERN.
+#
+# CERN Document Server is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CERN Document Server is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with CERN Document Server; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Test cds-dojson CLI and jsonschema compiler."""
+
+from __future__ import absolute_import
+
+import json
+import pkg_resources
+from click.testing import CliRunner
+
+from cds_dojson.cli import compile_schema
+
+
+def test_cli():
+    """Test cds-dojson CLI."""
+    runner = CliRunner()
+    result = runner.invoke(
+        compile_schema,
+        [pkg_resources.resource_filename(
+            'cds_dojson.schemas', 'records/video_src-v1.0.0.json'), ]
+    )
+
+    assert 0 == result.exit_code
+    compiled_schema_result = json.loads(result.output)
+    with open(pkg_resources.resource_filename(
+            'cds_dojson.schemas', 'records/video-v1.0.0.json'), 'r') as f:
+        compile_schema_expected = json.load(f)
+    assert compile_schema_expected == compiled_schema_result
+
+    result = runner.invoke(
+        compile_schema,
+        [pkg_resources.resource_filename(
+            'cds_dojson.schemas', 'records/project_src-v1.0.0.json'), ]
+    )
+
+    assert 0 == result.exit_code
+    compiled_schema_result = json.loads(result.output)
+    with open(pkg_resources.resource_filename(
+            'cds_dojson.schemas', 'records/project-v1.0.0.json'), 'r') as f:
+        compile_schema_expected = json.load(f)
+    assert compile_schema_expected == compiled_schema_result

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -28,13 +28,6 @@ def mock_path_to_url(self, path):
     return path
 
 
-def mock_get_schema(self, path):
-    """Mock the ``get_schema`` method of InvenioJSONSchemasState."""
-    with open(pkg_resources.resource_filename(
-            'cds.modules.records.jsonschemas', path), 'r') as f:
-        return json.load(f)
-
-
 def json_resolver(schema):
     """Test ``json_resolver``."""
     json_resolver = JSONResolver(plugins=['demo.json_resolver', ])


### PR DESCRIPTION
* Adds new version of video and project schemas with resolved references
  and compiled `allOf` keys. (closes CERNDocumentServer/cds#214)

* New `cds-dojson compile_schema` CLI to help building the compiled
  schemas.

* Adds `_deposit` key to base 