### PR TITLE
schemas: `keywords` fix

### DIFF
--- a/cds_dojson/schemas/deposits/records/project-v1.0.0.json
+++ b/cds_dojson/schemas/deposits/records/project-v1.0.0.json
@@ -118,7 +118,8 @@
            "value": {
              "type": "string"
            }
-         }
+         },
+         "type": "object"
        },
        "description": "",
        "type": "array"

--- a/cds_dojson/schemas/deposits/records/video-v1.0.0.json
+++ b/cds_dojson/schemas/deposits/records/video-v1.0.0.json
@@ -136,6 +136,7 @@
       "type": "array",
       "description": "",
       "items": {
+        "type": "object",
         "properties": {
           "source": {
             "type": "string"

--- a/cds_dojson/schemas/records/base-v1.0.0.json
+++ b/cds_dojson/schemas/records/base-v1.0.0.json
@@ -115,6 +115,7 @@
       "description": "",
       "type": "array",
       "items": {
+        "type": "object",
         "properties": {
           "source": {"type":"string"},
           "value": {"type":"string"}

--- a/cds_dojson/schemas/records/project-v1.0.0.json
+++ b/cds_dojson/schemas/records/project-v1.0.0.json
@@ -12,7 +12,8 @@
           "value": {
             "type": "string"
           }
-        }
+        },
+        "type": "object"
       },
       "type": "array"
     },
@@ -397,7 +398,8 @@
           "value": {
             "type": "string"
           }
-        }
+        },
+        "type": "object"
       },
       "type": "array"
     },

--- a/cds_dojson/schemas/records/video-v1.0.0.json
+++ b/cds_dojson/schemas/records/video-v1.0.0.json
@@ -215,7 +215,8 @@
           "value": {
             "type": "string"
           }
-        }
+        },
+        "type": "object"
       },
       "type": "array",
       "description": ""
@@ -453,7 +454,8 @@
           "value": {
             "type": "string"
           }
-        }
+        },
+        "type": "object"
       },
       "type": "array",
       "description": ""


### PR DESCRIPTION
* Adds `type` to `keywords.items` for compatability with SchemaForm.

Signed-off-by: Sourabh Lal sourabh.lal@cern.ch