### PR TITLE
schemas: require report numbers

### DIFF
--- a/cds_dojson/schemas/records/project-v1.0.0.json
+++ b/cds_dojson/schemas/records/project-v1.0.0.json
@@ -582,6 +582,7 @@
     "recid",
     "date",
     "category",
-    "type"
+    "type",
+    "report_number"
   ]
 }

--- a/cds_dojson/schemas/records/project_src-v1.0.0.json
+++ b/cds_dojson/schemas/records/project_src-v1.0.0.json
@@ -104,7 +104,8 @@
         "recid",
         "date",
         "category",
-        "type"
+        "type",
+        "report_number"
       ]
     }
   ]

--- a/cds_dojson/schemas/records/video-v1.0.0.json
+++ b/cds_dojson/schemas/records/video-v1.0.0.json
@@ -614,7 +614,8 @@
     "recid",
     "date",
     "category",
-    "type"
+    "type",
+    "report_number"
   ],
   "title": "CDS Base Record Schema v1.0.0"
 }

--- a/cds_dojson/schemas/records/video_src-v1.0.0.json
+++ b/cds_dojson/schemas/records/video_src-v1.0.0.json
@@ -117,7 +117,8 @@
         "recid",
         "date",
         "category",
-        "type"
+        "type",
+        "report_number"
       ]
     }
   ]


### PR DESCRIPTION
 * Video or project schemas for records have `report_number` as a
   required field.

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>