### PR TITLE
schemas: remove required fields of project deposit

### DIFF
--- a/cds_dojson/schemas/deposits/records/project-v1.0.0.json
+++ b/cds_dojson/schemas/deposits/records/project-v1.0.0.json
@@ -232,10 +232,7 @@
   },
   "description": "Describe information needed for deposit module.",
   "required": [
-    "_deposit",
-    "date",
-    "category",
-    "type"
+    "_deposit"
   ],
   "properties": {
     "report_number": {


### PR DESCRIPTION
 * Removes previously required fields of project deposit
   (`date`, `category`, `type`).

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>
commit dc9cf302aa671b22c328c37f6e2d94d2358f9b72