### PR TITLE
video: duration field required

### DIFF
--- a/cds_dojson/schemas/records/video-v1.0.0.json
+++ b/cds_dojson/schemas/records/video-v1.0.0.json
@@ -727,7 +727,8 @@
     "date",
     "category",
     "type",
-    "report_number"
+    "report_number",
+    "duration"
   ],
   "title": "CDS Base Record Schema v1.0.0"
 }

--- a/cds_dojson/schemas/records/video_src-v1.0.0.json
+++ b/cds_dojson/schemas/records/video_src-v1.0.0.json
@@ -115,7 +115,8 @@
         "date",
         "category",
         "type",
-        "report_number"
+        "report_number",
+        "duration"
       ]
     }
   ]


### PR DESCRIPTION
 * Makes the `duration` field required for video records. (closes #47)

 * Depends on #46.
    
Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>

