### PR TITLE
schemas: remove `.` from description

### DIFF
--- a/cds_dojson/schemas/deposits/records/project-v1.0.0.json
+++ b/cds_dojson/schemas/deposits/records/project-v1.0.0.json
@@ -72,7 +72,6 @@
       "type": "object"
     },
     "copyright": {
-      "description": ".",
       "properties": {
         "year": {
           "format": "date-time",

--- a/cds_dojson/schemas/deposits/records/video-v1.0.0.json
+++ b/cds_dojson/schemas/deposits/records/video-v1.0.0.json
@@ -154,8 +154,7 @@
           "type": "string",
           "description": "The party holding the legal copyright to the record."
         }
-      },
-      "description": "."
+      }
     },
     "keywords": {
       "items": {
@@ -284,7 +283,6 @@
     },
     "copyright": {
       "type": "object",
-      "description": ".",
       "properties": {
         "url": {
           "format": "url",
@@ -630,7 +628,6 @@
     "_files": {
       "name": "_files",
       "type": "array",
-      "description": ".",
       "items": {
         "type": "object",
         "description": "Describe information needed for files in records.",

--- a/cds_dojson/schemas/records/base-v1.0.0.json
+++ b/cds_dojson/schemas/records/base-v1.0.0.json
@@ -177,7 +177,6 @@
       "type": "string"
     },
     "copyright": {
-      "description": ".",
       "type": "object",
       "properties": {
         "holder": {

--- a/cds_dojson/schemas/records/project-v1.0.0.json
+++ b/cds_dojson/schemas/records/project-v1.0.0.json
@@ -234,7 +234,6 @@
           "format": "url"
         }
       },
-      "description": ".",
       "type": "object"
     },
     "language": {

--- a/cds_dojson/schemas/records/video-v1.0.0.json
+++ b/cds_dojson/schemas/records/video-v1.0.0.json
@@ -184,8 +184,7 @@
           "type": "string",
           "description": "The year during which the claimed copyright for the CreativeWork was first asserted."
         }
-      },
-      "description": "."
+      }
     },
     "identifier": {
       "type": "object",
@@ -327,8 +326,7 @@
         },
         "description": "A file object described using some basic subfields. (Usually to be extended)."
       },
-      "type": "array",
-      "description": "."
+      "type": "array"
     },
     "translations": {
       "items": {
@@ -529,8 +527,7 @@
           "type": "string",
           "description": "The year during which the claimed copyright for the CreativeWork was first asserted."
         }
-      },
-      "description": "."
+      }
     },
     "keywords": {
       "items": {

--- a/cds_dojson/schemas/records/video_src-v1.0.0.json
+++ b/cds_dojson/schemas/records/video_src-v1.0.0.json
@@ -63,7 +63,6 @@
           "type": "boolean"
         },
         "_files": {
-          "description": ".",
           "type": "array",
           "items":{
             "allOf": [


### PR DESCRIPTION
* Removes `.` from schema description. (closes CERNDocumentServer/cds#704)

Signed-off-by: Harris Tzovanakis <me@drjova.com>