### PR TITLE
video: vr field addition

### DIFF
--- a/cds_dojson/schemas/deposits/records/videos/video/video-v1.0.0.json
+++ b/cds_dojson/schemas/deposits/records/videos/video/video-v1.0.0.json
@@ -264,6 +264,9 @@
     }
   },
   "properties": {
+    "vr": {
+      "type": "boolean"
+    },
     "duration": {
       "type": "string"
     },

--- a/cds_dojson/schemas/deposits/records/videos/video/video_src-v1.0.0.json
+++ b/cds_dojson/schemas/deposits/records/videos/video/video_src-v1.0.0.json
@@ -25,6 +25,9 @@
               "type": "object"
             }
           }
+        },
+        "vr": {
+          "type": "boolean"
         }
       }
     },

--- a/cds_dojson/schemas/records/videos/video/video-v1.0.0.json
+++ b/cds_dojson/schemas/records/videos/video/video-v1.0.0.json
@@ -269,6 +269,9 @@
     }
   },
   "properties": {
+    "vr": {
+      "type": "boolean"
+    },
     "duration": {
       "type": "string"
     },

--- a/cds_dojson/schemas/records/videos/video/video_src-v1.0.0.json
+++ b/cds_dojson/schemas/records/videos/video/video_src-v1.0.0.json
@@ -56,6 +56,9 @@
         "date": { "$ref": "../../base-v1.0.0.json#/definitions/date" },
         "copyright": { "$ref": "../../base-v1.0.0.json#/definitions/copyright" },
         "license": { "$ref": "../../base-v1.0.0.json#/definitions/license" },
+        "vr": {
+          "type": "boolean"
+        },
         "duration": {
           "type": "string"
         },


### PR DESCRIPTION
* Adds a `vr` flag to videos, in order to selectively enable VR
  capabilities in THEOplayer.

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>