### PR TITLE
utils: fix repteable values MementoDict

### DIFF
--- a/cds_dojson/utils.py
+++ b/cds_dojson/utils.py
@@ -19,9 +19,8 @@
 """The CDS DoJson Utils."""
 
 import functools
-from collections import defaultdict
+from collections import MutableMapping, MutableSequence, defaultdict
 
-from collections import MutableMapping, MutableSequence
 import arrow
 import six
 
@@ -32,6 +31,19 @@ class MementoDict(dict):
     def __init__(self, *args, **kwargs):
         """Set memory and create the dictionary."""
         self.memory = set()
+        if args and isinstance(args[0], MutableSequence):
+            args = list(args)
+            d = {}
+            for k, v in args[0]:
+                if k in d:
+                    try:
+                        d[k].append(v)
+                    except AttributeError:
+                        d[k] = [d[k], v]
+                else:
+                    d[k] = v
+            args[0] = [(k, v) for k, v in six.iteritems(d)]
+
         super(MementoDict, self).__init__(*args, **kwargs)
 
     def iteritems(self, skyp_memento=False):
@@ -40,6 +52,7 @@ class MementoDict(dict):
             if not skyp_memento:
                 self.memory.add(key)
             yield (key, value)
+
     items = iteritems
 
     def __getitem__(self, key):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -60,7 +60,7 @@ def test_not_accessed_keys():
     d1 = MementoDict()
     assert not not_accessed_keys(d1)
 
-    d1['a'] = [1, 2, 3]
+    d1 = MementoDict([('a', [1, 2, 3])])
     assert not_accessed_keys(d1) == {'a'}
     d1['b'] = MementoDict({'1': 1})
     assert not_accessed_keys(d1) == {'a', 'b1'}
@@ -79,3 +79,22 @@ def test_not_accessed_keys():
     for k, v in d2.iteritems():
         pass
     assert not_accessed_keys(d1) == {'a', 'c', 'd1', 'd2'}
+
+    d1['e'] = MementoDict([('1', 1), ('1', 2), ('1', 3)])
+    assert not_accessed_keys(d1) == {'a', 'c', 'd1', 'd2', 'e1'}
+
+
+def test_memento_dict():
+    """Check MementoDict class."""
+    d = MementoDict({'a': 1, 'b': 2})
+    assert d == {'a': 1, 'b': 2}
+
+    d = MementoDict([('a', 1), ('b', 2)])
+    assert d == {'a': 1, 'b': 2}
+
+    d = MementoDict([('a', 1), ('a', 2)])
+    assert d == {'a': [1, 2]}
+
+    # NOTE: is this the expected behavior?
+    d = MementoDict([('a', 1), ('a', [2, 3])])
+    assert d == {'a': [1, [2, 3]]}


### PR DESCRIPTION
* Fixes MementoDict to key a list of values when the key has more that value and is initialized with a tuple.