### PR TITLE
marc21: translate language isocode

### DIFF
--- a/cds_dojson/marc21/fields/videos/utils.py
+++ b/cds_dojson/marc21/fields/videos/utils.py
@@ -195,7 +195,7 @@ def language_to_isocode(lang):
     lang = lang.lower()
     try:
         return pycountry.languages.get(alpha_3=lang).alpha_2
-    except KeyError, AttributeError:
+    except (KeyError, AttributeError):
         exceptions = {
             'eng-fre': 'en-fr',
             'silent': 'silent',

--- a/cds_dojson/marc21/fields/videos/utils.py
+++ b/cds_dojson/marc21/fields/videos/utils.py
@@ -19,6 +19,7 @@
 """Video utils."""
 
 import re
+import pycountry
 
 from dojson.utils import force_list
 from six import iteritems
@@ -187,3 +188,17 @@ def build_contributor(value):
         contributors.append(
             dict((k, v) for k, v in iteritems(contributor) if v is not None))
     return contributors
+
+
+def language_to_isocode(lang):
+    """Translate language to isocode."""
+    lang = lang.lower()
+    try:
+        return pycountry.languages.get(alpha_3=lang).alpha_2
+    except KeyError, AttributeError:
+        exceptions = {
+            'eng-fre': 'en-fr',
+            'silent': 'silent',
+            'sil': 'silent',
+        }
+        return exceptions.get(lang)

--- a/cds_dojson/marc21/fields/videos/video.py
+++ b/cds_dojson/marc21/fields/videos/video.py
@@ -18,12 +18,14 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 """Video fields."""
 
+from __future__ import absolute_import, print_function
+
 import re
 
 from dojson.utils import filter_values, for_each_value, force_list
 
 from ...models.videos.video import model
-from .utils import build_contributor
+from .utils import build_contributor, language_to_isocode
 
 
 # Required fields
@@ -114,3 +116,11 @@ def access(self, key, value):
                 for s in force_list(value.get('d') or value.get('m', '')) if s
             ])
     return _access
+
+
+# Language
+
+@model.over('language', '^041__')
+def language(self, key, value):
+    """Language."""
+    return language_to_isocode(value.get('a'))

--- a/cds_dojson/marc21/models/videos/video.py
+++ b/cds_dojson/marc21/models/videos/video.py
@@ -31,7 +31,10 @@ class CDSVideo(OverdoJSONSchema):
 
     __schema__ = 'records/videos/video/video-v1.0.0.json'
 
-    __ignore_keys__ = {'035__9', '035__a', '5061_2', '5061_5', '5061_a'}
+    __ignore_keys__ = {
+        '035__9', '035__a', '5061_2', '5061_5', '5061_a', '0248_a', '0248_p',
+        '0248_q',
+    }
 
 
 model = CDSVideo(bases=(cds_base, ),

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ tests_require = [
     'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',
     'pytest>=2.8.0',
+    'pycountry>=17.5.14',
 ]
 
 extras_require = {

--- a/tests/fixtures/videos_video.xml
+++ b/tests/fixtures/videos_video.xml
@@ -2,6 +2,11 @@
   <record>
     <controlfield tag="001">2272973</controlfield>
     <controlfield tag="005">20170704112045.0</controlfield>
+    <datafield tag="0248" ind1=" " ind2=" ">
+      <subfield code="a">test a</subfield>
+      <subfield code="p">test p</subfield>
+      <subfield code="q">test q</subfield>
+    </datafield>
     <datafield tag="037" ind1=" " ind2=" ">
       <subfield code="a">CERN-MOVIE-2017-023-001</subfield>
     </datafield>
@@ -50,7 +55,7 @@
       <subfield code="m">example@test.com</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
-      <subfield code="a">Where were you on 4 July 2012, the day in which the Higgs boson discovery was announced? Many people will be able to answer without referring to their diary. Perhaps you were among the few who had managed to secure a seat in CERN’s main auditorium, or who joined colleagues in universities and laboratories around the world at odd times of the day to watch the webcast. “I think we have it, no?” was the question posed by the then CERN Director General Rolf Heuer on 4 July in the CERN auditorium. The answer was as obvious as the emotion on faces in the crowd. The then ATLAS and CMS spokespersons, Fabiola Gianotti and Joe Incandela, had just presented the latest Higgs search results based on roughly two years of LHC operations. Given the hints for the Higgs presented a few months earlier in December 2011, the frenzy of rumours on blogs and intense media interest during the preceding weeks, and a title for the CERN seminar that left little to the imagination, the outcome was anticipated. This did not temper excitement.</subfield>
+      <subfield code="a">Where were you on 4 July 2012, the day in which the Higgs boson discovery was announced?</subfield>
     </datafield>
     <datafield tag="542" ind1=" " ind2=" ">
       <subfield code="d">CERN</subfield>

--- a/tests/test_videos_video.py
+++ b/tests/test_videos_video.py
@@ -18,6 +18,7 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 """Video rules tests."""
 
+from cds_dojson.marc21.fields.videos.utils import language_to_isocode
 from cds_dojson.marc21.models.videos.video import model
 from cds_dojson.marc21.utils import create_record
 from helpers import load_fixture_file, validate
@@ -32,7 +33,8 @@ def test_required_fields(app):
         record = model.do(blob)
 
         assert record['$schema'] == {
-            '$ref': 'https://cds.cern.ch/schemas/records/videos/video/video-v1.0.0.json'
+            '$ref': ('https://cds.cern.ch/schemas/records/videos/video/'
+                     'video-v1.0.0.json')
         }
         assert record['recid'] == 2272973
         assert record['date'] == '2017-07-04'
@@ -65,7 +67,18 @@ def test_required_fields(app):
                 'christoph.martin.madsen@cern.ch',
             ]
         }
+        assert record['language'] == 'en'
 
         # Add required fields calculated by post-process tasks.
         record['publication_date'] = '2017-07-04'
         validate(record)
+
+
+def test_language_to_isocode():
+    """Test language to isocode."""
+    assert language_to_isocode('eng') == 'en'
+    assert language_to_isocode('eng-fre') == 'en-fr'
+    assert language_to_isocode('ITA') == 'it'
+    assert language_to_isocode('silent') == 'silent'
+    assert language_to_isocode('sil') == 'silent'
+    assert language_to_isocode('fuu') is None

--- a/tests/test_videos_video.py
+++ b/tests/test_videos_video.py
@@ -32,42 +32,50 @@ def test_required_fields(app):
         blob = create_record(marcxml)
         record = model.do(blob)
 
-        assert record['$schema'] == {
-            '$ref': ('https://cds.cern.ch/schemas/records/videos/video/'
-                     'video-v1.0.0.json')
+        assert record == {
+            '$schema': {
+                '$ref': ('https://cds.cern.ch/schemas/records/videos/video/'
+                         'video-v1.0.0.json')
+            },
+            '_access': {'read': ['test-group@cern.ch',
+                                 'cds-admin@cern.ch',
+                                 'test-email@cern.ch',
+                                 'example@test.com'],
+                        'update': ['Jacques.Fichet@cern.ch',
+                                   'christoph.martin.madsen@cern.ch']},
+            'category': 'CERN',
+            'contributors': [
+                {'name': 'CERN Video Productions', 'role': 'Producer'},
+                {'name': 'CERN Video Productions', 'role': 'Director'},
+                {'affiliations': (u'CERN',),
+                 'email': u'christoph.martin.madsen@cern.ch',
+                 'ids': [{'source': 'CERN', 'value': u'755568'},
+                         {'source': 'CDS', 'value': u'2090563'}],
+                 'name': 'Madsen, Christoph Martin',
+                 'role': 'Director'},
+                {'affiliations': (u'CERN',),
+                 'email': u'Paola.Catapano@cern.ch',
+                 'ids': [{'source': 'CERN', 'value': u'380837'},
+                         {'source': 'CDS', 'value': u'2050975'}],
+                 'name': 'Catapano, Paola',
+                 'role': 'Director'},
+                {'affiliations': (u'CERN',),
+                 'email': u'christoph.martin.madsen@cern.ch',
+                 'ids': [{'source': 'CERN', 'value': u'755568'},
+                         {'source': 'CDS', 'value': u'2090563'}],
+                 'name': 'Madsen, Christoph Martin',
+                 'role': 'Editor'}],
+            'date': '2017-07-04',
+            'description': ('Where were you on 4 July 2012, the day in which '
+                            'the Higgs boson discovery was announced?'),
+            'duration': '00:01:09',
+            'language': u'en',
+            'modification_date': '20170704112045.0',
+            'recid': 2272973,
+            'report_number': ['CERN-MOVIE-2017-023-001'],
+            'title': {'title': 'Happy 5th anniversary, Higgs boson!'},
+            'type': 'MOVIE'
         }
-        assert record['recid'] == 2272973
-        assert record['date'] == '2017-07-04'
-        assert record['duration'] == '00:01:09'
-        assert record['title'][
-            'title'] == 'Happy 5th anniversary, Higgs boson!'
-        assert record['contributors'][0] == {
-            'name': u'CERN Video Productions',
-            'role': 'Producer'
-        }
-        assert record['contributors'][-1] == {
-            'affiliations': ('CERN', ),
-            'email': 'christoph.martin.madsen@cern.ch',
-            'ids': [
-                {'source': 'CERN', 'value': u'755568'},
-                {'source': 'CDS', 'value': u'2090563'}
-            ],
-            'name': 'Madsen, Christoph Martin',
-            'role': 'Editor'
-        }
-        assert record['_access'] == {
-            'read': [
-                'test-group@cern.ch',
-                'cds-admin@cern.ch',
-                'test-email@cern.ch',
-                'example@test.com',
-            ],
-            'update': [
-                'Jacques.Fichet@cern.ch',
-                'christoph.martin.madsen@cern.ch',
-            ]
-        }
-        assert record['language'] == 'en'
 
         # Add required fields calculated by post-process tasks.
         record['publication_date'] = '2017-07-04'
@@ -82,3 +90,4 @@ def test_language_to_isocode():
     assert language_to_isocode('silent') == 'silent'
     assert language_to_isocode('sil') == 'silent'
     assert language_to_isocode('fuu') is None
+    assert language_to_isocode('test >3 chars') is None


### PR DESCRIPTION
* Adds function to translate language code.

* Adds oaiset fields. (closes #78)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>