### PR TITLE
marc21: fix internal_* fields

### DIFF
--- a/cds_dojson/schemas/deposits/records/videos/project/project-v1.0.0.json
+++ b/cds_dojson/schemas/deposits/records/videos/project/project-v1.0.0.json
@@ -401,7 +401,11 @@
       "type": "string", 
       "description": "Internal note.", 
       "title": "Internal note"
-    }, 
+    },
+    "internal_categories": {
+      "description": "FIXME: temporary location for potential future communities",
+      "type": "object"
+    },
     "doi": {
       "type": "string", 
       "description": "Record DOI identifier (string)."

--- a/cds_dojson/schemas/deposits/records/videos/video/video-v1.0.0.json
+++ b/cds_dojson/schemas/deposits/records/videos/video/video-v1.0.0.json
@@ -509,7 +509,11 @@
       "type": "string", 
       "description": "Internal note.", 
       "title": "Internal note"
-    }, 
+    },
+    "internal_categories": {
+      "description": "FIXME: temporary location for potential future communities",
+      "type": "object"
+    },
     "doi": {
       "type": "string", 
       "description": "Record DOI identifier (string)."

--- a/cds_dojson/schemas/records/definitions-v1.0.0.json
+++ b/cds_dojson/schemas/records/definitions-v1.0.0.json
@@ -346,6 +346,10 @@
       "description": "Internal note.",
       "type": "string"
     },
+    "internal_categories": {
+      "description": "FIXME: temporary location for potential future communities",
+      "type": "object"
+    },
     "subject": {
       "title": "Subject",
       "description": "Subject.",

--- a/cds_dojson/schemas/records/videos/project/project-v1.0.0.json
+++ b/cds_dojson/schemas/records/videos/project/project-v1.0.0.json
@@ -349,7 +349,11 @@
       "type": "string", 
       "description": "Internal note.", 
       "title": "Internal note"
-    }, 
+    },
+    "internal_categories": {
+      "description": "FIXME: temporary location for potential future communities",
+      "type": "object"
+    },
     "doi": {
       "type": "string", 
       "description": "Record DOI identifier (string)."

--- a/cds_dojson/schemas/records/videos/project/project_src-v1.0.0.json
+++ b/cds_dojson/schemas/records/videos/project/project_src-v1.0.0.json
@@ -66,6 +66,7 @@
         "license": { "$ref": "../../definitions-v1.0.0.json#/definitions/license" },
         "note": { "$ref": "../../definitions-v1.0.0.json#/definitions/note" },
         "internal_note": { "$ref": "../../definitions-v1.0.0.json#/definitions/internal_note" },
+        "internal_categories": { "$ref": "../../definitions-v1.0.0.json#/definitions/internal_categories" },
         "subject": { "$ref": "../../definitions-v1.0.0.json#/definitions/subject" },
         "external_system_identifiers": { "$ref": "../../definitions-v1.0.0.json#/definitions/external_system_identifiers" },
         "_files": {

--- a/cds_dojson/schemas/records/videos/video/video-v1.0.0.json
+++ b/cds_dojson/schemas/records/videos/video/video-v1.0.0.json
@@ -469,7 +469,11 @@
       "type": "string", 
       "description": "Internal note.", 
       "title": "Internal note"
-    }, 
+    },
+    "internal_categories": {
+      "description": "FIXME: temporary location for potential future communities",
+      "type": "object"
+    },
     "doi": {
       "type": "string", 
       "description": "Record DOI identifier (string)."

--- a/cds_dojson/schemas/records/videos/video/video_src-v1.0.0.json
+++ b/cds_dojson/schemas/records/videos/video/video_src-v1.0.0.json
@@ -70,6 +70,7 @@
         "physical_medium": { "$ref": "../../definitions-v1.0.0.json#/definitions/physical_medium" },
         "note": { "$ref": "../../definitions-v1.0.0.json#/definitions/note" },
         "internal_note": { "$ref": "../../definitions-v1.0.0.json#/definitions/internal_note" },
+        "internal_categories": { "$ref": "../../definitions-v1.0.0.json#/definitions/internal_categories" },
         "subject": { "$ref": "../../definitions-v1.0.0.json#/definitions/subject" },
         "accelerator_experiment": { "$ref": "../../definitions-v1.0.0.json#/definitions/accelerator_experiment" },
         "external_system_identifiers": { "$ref": "../../definitions-v1.0.0.json#/definitions/external_system_identifiers" },

--- a/tests/test_videos_video.py
+++ b/tests/test_videos_video.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of CERN Document Server.
-# Copyright (C) 2017 CERN.
+# Copyright (C) 2017, 2018 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -622,23 +622,38 @@ def test_fields(app):
             """
             <datafield tag="595" ind1=" " ind2=" ">
                 <subfield code="a">test1</subfield>
-                <subfield code="s">test2</subfield>
             </datafield>
-            """, {'internal_note': 'test1, test2'}
-        )
-        check_transformation(
-            """
-            <datafield tag="595" ind1=" " ind2=" ">
-                <subfield code="s">test2</subfield>
-            </datafield>
-            """, {'internal_note': 'test2'}
+            """, {'internal_note': 'test1'}
         )
         check_transformation(
             """
             <datafield tag="595" ind1=" " ind2=" ">
                 <subfield code="a">test1</subfield>
             </datafield>
-            """, {'internal_note': 'test1'}
+            <datafield tag="595" ind1=" " ind2=" ">
+                <subfield code="a">test2</subfield>
+            </datafield>
+            """, {'internal_note': 'test1\ntest2'}
+        )
+        check_transformation(
+            """
+            <datafield tag="595" ind1=" " ind2=" ">
+                <subfield code="a">CERN50</subfield>
+                <subfield code="s">AcceleratorsDetectors</subfield>
+            </datafield>
+            """, {'internal_categories': {'CERN50': ['AcceleratorsDetectors']}}
+        )
+        check_transformation(
+            """
+            <datafield tag="595" ind1=" " ind2=" ">
+                <subfield code="a">test1</subfield>
+            </datafield>
+             <datafield tag="595" ind1=" " ind2=" ">
+                <subfield code="a">CERN50</subfield>
+                <subfield code="s">AcceleratorsDetectors</subfield>
+            </datafield>
+            """, {'internal_note': 'test1',
+                  'internal_categories': {'CERN50': ['AcceleratorsDetectors']}}
         )
         check_transformation(
             """


### PR DESCRIPTION
* Fixes internal_note fields when 595 has multiple values

* Add new field internal_categories to keep the possible future
  communities stored inside 595. (addresses CERNDocumentServer/cds-videos#1576)