### PR TITLE
marc21: fix rule for external identifiers (035)

### DIFF
--- a/cds_dojson/marc21/fields/books/values_mapping.py
+++ b/cds_dojson/marc21/fields/books/values_mapping.py
@@ -117,6 +117,34 @@ MATERIALS = [
 SUBJECT_CLASSIFICATION_EXCEPTIONS = \
     ['PACS', 'CERN LIBRARY', 'CERN YELLOW REPORT']
 
+EXTERNAL_SYSTEM_IDENTIFIERS = [
+    'ARXIV',
+    'DCL',
+    'DESY',
+    'DOE',
+    'EBL',
+    'FIZ',
+    'HAL',
+    'IEECONF',
+    'INDICO.CERN.CH',
+    'INIS',
+    'INSPIRE',
+    'KEK',
+    'LHCLHC',
+    'SAFARI',
+    'SCEM',
+    'UDCCERN',
+    'WAI01',
+]
+
+EXTERNAL_SYSTEM_IDENTIFIERS_TO_IGNORE = [
+    'CERN ANNUAL REPORT',
+    'HTTP://INSPIREHEP.NET/OAI2D',
+    'SLAC',
+    'SLACCONF',
+    'SPIRES',
+]
+
 
 def mapping(field_map, val, raise_exception=False):
     """

--- a/cds_dojson/schemas/records/books/ymls/base-v0.0.1.yml
+++ b/cds_dojson/schemas/records/books/ymls/base-v0.0.1.yml
@@ -355,6 +355,25 @@ properties:
                         Identifies the external system, and allows to interpret
                         unambiguously the :ref:`value`.
                         :example: ``ADS``
+                    enum:
+                    - ARXIV
+                    - DCL
+                    - DESY
+                    - DOE
+                    - EBL
+                    - FIZ
+                    - HAL
+                    - IEECONF
+                    - INDICO.CERN.CH
+                    - INIS
+                    - INSPIRE
+                    - INSPIRE-CNUM
+                    - KEK
+                    - LHCLHC
+                    - SAFARI
+                    - SCEM
+                    - UDCCERN
+                    - WAI01
                     minLength: 1
                     pattern: ^\w+$
                     type: string

--- a/tests/test_books.py
+++ b/tests/test_books.py
@@ -1006,34 +1006,44 @@ def test_external_system_identifiers(app):
                 <subfield code="a">2365039</subfield>
             </datafield>
             <datafield tag="035" ind1=" " ind2=" ">
-                <subfield code="9">Random</subfield>
+                <subfield code="9">Inspire</subfield>
                 <subfield code="a">2365039</subfield>
             </datafield>
             """, {
-                'inspire_cnum': '2365039',
+                'conference_info': [{
+                    'inspire_cnum': '2365039',
+                }],
                 'external_system_identifiers': [{
-                    'schema': 'Random',
+                    'schema': 'Inspire',
                     'value': '2365039',
                 }],
             })
 
+        with pytest.raises(UnexpectedValue):
+            check_transformation(
+                """
+                <datafield tag="035" ind1=" " ind2=" ">
+                    <subfield code="9">Random</subfield>
+                    <subfield code="a">2365039</subfield>
+                </datafield>
+                """, {
+                })
+
+        with pytest.raises(UnexpectedValue):
+            check_transformation(
+                """
+                <datafield tag="035" ind1=" " ind2=" ">
+                    <subfield code="9">CERCER</subfield>
+                    <subfield code="a">2365039</subfield>
+                </datafield>
+                """, {
+                })
+
         check_transformation(
             """
             <datafield tag="035" ind1=" " ind2=" ">
-                <subfield code="9">Random</subfield>
-                <subfield code="a">2365039</subfield>
-            </datafield>
-            """, {
-                'external_system_identifiers': [{
-                    'schema': 'Random',
-                    'value': '2365039',
-                }],
-            })
-        check_transformation(
-            """
-            <datafield tag="035" ind1=" " ind2=" ">
-                <subfield code="9">CERCER</subfield>
-                <subfield code="a">2365039</subfield>
+                <subfield code="9">SLAC</subfield>
+                <subfield code="a">5231528</subfield>
             </datafield>
             """, {
             })


### PR DESCRIPTION
* Adds new lists for external identifiers in order to determine
  which values should be allowed and which to be ignored.
  (closes #167)

Signed-off-by: Ludmila Marian <ludmila.marian@gmail.com>