### PR TITLE
books: updates to serials and multiparts

### DIFF
--- a/cds_dojson/marc21/fields/books/multipart.py
+++ b/cds_dojson/marc21/fields/books/multipart.py
@@ -22,6 +22,7 @@ import re
 from dojson.errors import IgnoreKey
 from dojson.utils import for_each_value, filter_values, force_list
 
+from cds_dojson.marc21.fields.books.base import book_series as base_book_series
 from cds_dojson.marc21.fields.books.errors import UnexpectedValue, \
     ManualMigrationRequired, MissingRequiredField
 from cds_dojson.marc21.fields.books.utils import extract_parts, \
@@ -100,7 +101,9 @@ def migration(self, key, value):
     _series_title = self.get('title', None)
 
     # I added this in the model, I'm sure it's there
-    _migration = self.get('_migration', {'volumes': []})
+    _migration = self.get('_migration', {})
+    if 'volumes' not in _migration:
+        _migration['volumes'] = []
 
     for v in force_list(value):
         # check if it is a multipart monograph
@@ -158,3 +161,10 @@ def number_of_volumes(self, key, value):
         if _volumes:
             return _volumes[0]
     raise IgnoreKey('number_of_volumes')
+
+
+@model.over('book_series', '^490__')
+@for_each_value
+def book_series(self, key, value):
+    """Match barcodes to volumes."""
+    base_book_series(self, key, value)

--- a/cds_dojson/marc21/fields/utils.py
+++ b/cds_dojson/marc21/fields/utils.py
@@ -371,8 +371,10 @@ def build_contributor_books(value):
         'ids': _extract_json_ids(value, 'schema') or None,
         'full_name': value.get('name') or clean_val('a', value, str),
         'email': clean_email(value.get('email')),
-        'role': _get_correct_books_contributor_role(
-            'e', value.get('e', 'author')),
+        'roles': [
+            _get_correct_books_contributor_role(
+                'e', value.get('e', 'author')).lower()
+        ],
         'curated_relation': True if value_9 == '#BEARD#' else None
     }
 

--- a/cds_dojson/marc21/models/books/base.py
+++ b/cds_dojson/marc21/models/books/base.py
@@ -164,5 +164,5 @@ class BooksBase(OverdoJSONSchema):
     """Base model conversion MARC21 to JSON."""
 
 
-model = BooksBase(bases=(cds_base, ),
+model = BooksBase(bases=(),
                   entry_point_group='cds_dojson.marc21.books')

--- a/cds_dojson/marc21/models/books/book.py
+++ b/cds_dojson/marc21/models/books/book.py
@@ -31,7 +31,7 @@ class CDSBook(CDSOverdoBookBase):
                 '690C_:BOOKSUGGESTION OR 980__:PROCEEDINGS OR 980__:PERI OR ' \
                 '697C_:LEGSERLIB OR 697C_:"ENGLISH BOOK CLUB" -980__:DELETED'
 
-    __schema__ = 'records/books/book/book-v.0.0.1.json'
+    __schema__ = 'https://127.0.0.1:5000/schemas/documents/document-v1.0.0.json'
 
     __ignore_keys__ = COMMON_IGNORE_FIELDS
 
@@ -44,24 +44,28 @@ class CDSBook(CDSOverdoBookBase):
         json['$schema'] = self.__class__.__schema__
 
         if '_migration' in json:
-            json['_migration'].update({'record_type': 'document'})
+            json['_migration'].setdefault('record_type', 'document')
+            json['_migration'].setdefault('volumes', [])
+            json['_migration'].setdefault('serials', [])
             json['_migration'].setdefault('has_serial', False)
-            json['_migration'].setdefault('has_multipart', False)
+            json['_migration'].setdefault('is_multipart', False)
             json['_migration'].setdefault('has_keywords', False)
             json['_migration'].setdefault('has_related', False)
+
         else:
             json['_migration'] = {
                 'record_type': 'document',
                 'has_serial': False,
-                'has_multipart': False,
+                'is_multipart': False,
                 'has_keywords': False,
                 'has_related': False,
-                'volumes': []
+                'volumes': [],
+                'serials': [],
             }
 
         return json
 
 
 model = CDSBook(
-    bases=(books_base, cds_base, ),
+    bases=(books_base, ),
     entry_point_group='cds_dojson.marc21.book')

--- a/cds_dojson/marc21/models/books/standard.py
+++ b/cds_dojson/marc21/models/books/standard.py
@@ -44,7 +44,7 @@ class CDSStandard(CDSOverdoBookBase):
         json['_migration'] = {
             'record_type': 'document',
             'has_serial': False,
-            'has_multipart': False,
+            'is_multipart': False,
             'has_keywords': False,
             'has_related': False,
             'volumes': []

--- a/tests/test_books.py
+++ b/tests/test_books.py
@@ -38,14 +38,16 @@ def check_transformation(marcxml_body, json_body):
     blob = create_record(marcxml.format(marcxml_body))
     record = model.do(blob, ignore_missing=False)
     expected = {
-        '$schema': 'records/books/book/book-v.0.0.1.json',
-        '_migration': {'has_keywords': False,
-                       'has_multipart': False,
-                       'has_related': False,
-                       'has_serial': False,
-                       'record_type': 'document',
-                       'volumes': []
-                       }
+        '$schema': 'https://127.0.0.1:5000/schemas/documents/document-v1.0.0.json',
+        '_migration': {
+            'has_keywords': False,
+            'is_multipart': False,
+            'has_related': False,
+            'has_serial': False,
+            'record_type': 'document',
+            'volumes': [],
+            'serials': [],
+        }
     }
     expected.update(**json_body)
     assert record == expected
@@ -154,12 +156,21 @@ def test_subject_classification(app):
                 <subfield code="a">25.80.Nv</subfield>
             </datafield>
             """, {
-                'keywords': [
-                    {'name': '13.75.Jz', 'provenance': 'PACS'},
-                    {'name': '13.60.Rj', 'provenance': 'PACS'},
-                    {'name': '14.20.Jn', 'provenance': 'PACS'},
-                    {'name': '25.80.Nv', 'provenance': 'PACS'},
-                ]
+                '_migration': {
+                    'has_keywords': True,
+                    'is_multipart': False,
+                    'has_related': False,
+                    'has_serial': False,
+                    'record_type': 'document',
+                    'volumes': [],
+                    'serials': [],
+                    'keywords': [
+                        {'name': '13.75.Jz', 'provenance': 'PACS'},
+                        {'name': '13.60.Rj', 'provenance': 'PACS'},
+                        {'name': '14.20.Jn', 'provenance': 'PACS'},
+                        {'name': '25.80.Nv', 'provenance': 'PACS'},
+                    ]
+                }
             }
         )
         check_transformation(
@@ -514,20 +525,20 @@ def test_authors(app):
                 'authors': [
                     {
                         'full_name': 'Frampton, Paul H',
-                        'role': 'Editor',
+                        'roles': ['editor'],
                         'alternative_names': 'Neubert, Matthias'
                     },
                     {
                         'full_name': 'Glashow, Sheldon Lee',
-                        'role': 'Editor'
+                        'roles': ['editor']
                     },
                     {
                         'full_name': 'Van Dam, Hendrik',
-                        'role': 'Editor'
+                        'roles': ['editor']
                     },
                     {
                         'full_name': 'Seyfert, Paul',
-                        'role': 'Author',
+                        'roles': ['author'],
                         'affiliations': ['CERN'],
                         'ids': [
                             {'schema': 'INSPIRE ID',
@@ -542,12 +553,12 @@ def test_authors(app):
                     },
                     {
                         'full_name': 'John Doe',
-                        'role': 'Author',
+                        'roles': ['author'],
                         'affiliations': ['CERN', 'Univ. Gent'],
                     },
                     {
                         'full_name': 'Jane Doe',
-                        'role': 'Author',
+                        'roles': ['author'],
                         'affiliations': ['CERN', 'Univ. Gent'],
                     }
                 ],
@@ -569,12 +580,12 @@ def test_authors(app):
                 'authors': [
                     {
                         'full_name': 'Frampton, Paul H',
-                        'role': 'Editor',
+                        'roles': ['editor'],
                     },
                     {'others': True},
                     {
                         'full_name': 'Glashow, Sheldon Lee',
-                        'role': 'Editor'
+                        'roles': ['editor']
                     },
                 ]
             }
@@ -2110,10 +2121,21 @@ def test_book_series(app):
                 <subfield code="a">Minutes</subfield>
             </datafield>
             """, {
-                'book_series':
-                    [
-                        {'title': 'Minutes'},
-                    ]
+                '_migration': {
+                    'serials': [
+                        {
+                            'title': 'Minutes',
+                            'issn': None,
+                            'volume': None
+                        }
+                    ],
+                    'has_keywords': False,
+                    'is_multipart': False,
+                    'has_related': False,
+                    'has_serial': True,
+                    'record_type': 'document',
+                    'volumes': [],
+                }
             }
         )
         check_transformation(
@@ -2125,12 +2147,21 @@ def test_book_series(app):
                 <subfield code="v">16</subfield>
             </datafield>
             """, {
-                'book_series':
-                    [
-                        {'title': 'De Gruyter studies in mathematical physics',
-                         'volume': '16',
-                         },
-                    ]
+                '_migration': {
+                    'serials': [
+                        {
+                            'title': 'De Gruyter studies in mathematical physics',
+                            'issn': None,
+                            'volume': '16'
+                        }
+                    ],
+                    'has_keywords': False,
+                    'is_multipart': False,
+                    'has_related': False,
+                    'has_serial': True,
+                    'record_type': 'document',
+                    'volumes': [],
+                }
             }
         )
         check_transformation(
@@ -2141,13 +2172,21 @@ def test_book_series(app):
                 <subfield code="x">0081-3869</subfield>
             </datafield>
             """, {
-                'book_series':
-                    [
-                        {'title': 'Springer tracts in modern physics',
-                         'volume': '267',
-                         'issn': '0081-3869',
-                         },
-                    ]
+                '_migration': {
+                    'serials': [
+                        {
+                            'title': 'Springer tracts in modern physics',
+                            'issn': '0081-3869',
+                            'volume': '267'
+                        }
+                    ],
+                    'has_keywords': False,
+                    'is_multipart': False,
+                    'has_related': False,
+                    'has_serial': True,
+                    'record_type': 'document',
+                    'volumes': [],
+                }
             }
         )
 
@@ -2267,27 +2306,27 @@ def test_541(app):
                     ],
                     'authors': [
                         {
-                            'role': "Editor",
+                            'role': "editor",
                             'full_name': "Cai, Baoping"
                         },
                         {
-                            'role': "Editor",
+                            'role': "editor",
                             'full_name': "Liu, Yonghong"
                         },
                         {
-                            'role': "Editor",
+                            'role': "editor",
                             'full_name': "Hu, Jinqiu"
                         },
                         {
-                            'role': "Editor",
+                            'role': "editor",
                             'full_name': "Liu, Zengkai"
                         },
                         {
-                            'role': "Editor",
+                            'role': "editor",
                             'full_name': "Wu, Shengnan"
                         },
                         {
-                            'role': "Editor",
+                            'role': "editor",
                             'full_name': "Ji, Renjie"
                         }
                     ],
@@ -2324,9 +2363,18 @@ def test_keywords(app):
             </datafield>
             """,
             {
-                'keywords': [
-                    {'name': 'Keyword Name 1', 'provenance': 'PACS'},
-                ]
+                '_migration': {
+                    'has_keywords': True,
+                    'is_multipart': False,
+                    'has_related': False,
+                    'has_serial': False,
+                    'record_type': 'document',
+                    'volumes': [],
+                    'serials': [],
+                    'keywords': [
+                        {'name': 'Keyword Name 1', 'provenance': 'PACS'},
+                    ],
+                }
             }
         )
 
@@ -2353,13 +2401,14 @@ def test_volume_barcodes(app):
                 _migration=dict(
                     record_type='document',
                     has_serial=False,
-                    has_multipart=False,
+                    is_multipart=False,
                     has_keywords=False,
                     has_related=False,
                     volumes=[
                         dict(barcode='80-1209-8', volume=1),
                         dict(barcode='B00004172', volume=1),
-                    ]
+                    ],
+                    serials=[]
                 ),
             )
         )

--- a/tests/test_standard.py
+++ b/tests/test_standard.py
@@ -33,7 +33,7 @@ def check_transformation(marcxml_body, json_body):
     expected = {
         '$schema': 'records/books/book/book-v.0.0.1.json',
         '_migration': {'has_keywords': False,
-                       'has_multipart': False,
+                       'is_multipart': False,
                        'has_related': False,
                        'has_serial': False,
                        'record_type': 'document',


### PR DESCRIPTION
* Store serials in `_migration.serials`
* Store keywords in `_migration.keywords`
* Change `role` to `roles` and store the value in lowercase
* Use `has_keyword`, `is_multipart` and `has_serial` to indicate if the record has any keywords, multipart or serials
* Implemented volumes for `document` record type

Closes #238