### PR TITLE
Field fixes

### DIFF
--- a/cds_dojson/marc21/fields/books/base.py
+++ b/cds_dojson/marc21/fields/books/base.py
@@ -638,7 +638,7 @@ def languages(self, key, value):
     """Translates languages fields."""
     lang = clean_val('a', value, str).lower()
     try:
-        return pycountry.languages.lookup(lang).alpha_2
+        return pycountry.languages.lookup(lang).alpha_2.upper()
     except (KeyError, AttributeError, LookupError):
         raise UnexpectedValue(subfield='a')
 
@@ -750,7 +750,7 @@ def alternative_titles(self, key, value):
 @out_strip
 def edition(self, key, value):
     """Translates edition indicator field."""
-    return clean_val('a', value, str)
+    return clean_val('a', value, str).replace("ed.", "")
 
 
 @model.over('imprint', '^260__')

--- a/cds_dojson/marc21/fields/books/journal.py
+++ b/cds_dojson/marc21/fields/books/journal.py
@@ -110,7 +110,7 @@ def languages(self, key, value):
     """Translates languages fields."""
     lang = clean_val('a', value, str).lower()
     try:
-        return pycountry.languages.lookup(lang).alpha_2
+        return pycountry.languages.lookup(lang).alpha_2.upper()
     except (KeyError, AttributeError, LookupError):
         raise UnexpectedValue(subfield='a')
 

--- a/cds_dojson/marc21/fields/books/values_mapping.py
+++ b/cds_dojson/marc21/fields/books/values_mapping.py
@@ -40,10 +40,10 @@ COLLECTION = {
 }
 
 ACQUISITION_METHOD = {
-    'user': ['H'],
+    # mapping for possible value of "created_by.type" field
+    'user': ['H', 'r'],
     'batchuploader': ['N', 'M'],
     'migration': ['migration'],
-    'r': 'user'
 }
 
 MEDIUM_TYPES = [

--- a/cds_dojson/marc21/fields/utils.py
+++ b/cds_dojson/marc21/fields/utils.py
@@ -413,7 +413,7 @@ def build_contributor_books(value):
         'full_name': value.get('name') or clean_val('a', value, str),
         'roles': [
             _get_correct_books_contributor_role(
-                'e', value.get('e', 'author')).lower()
+                'e', value.get('e', 'author'))
         ],
     }
 

--- a/tests/test_books.py
+++ b/tests/test_books.py
@@ -642,20 +642,20 @@ def test_authors(app):
                 'authors': [
                     {
                         'full_name': 'Frampton, Paul H',
-                        'roles': ['editor'],
+                        'roles': ['EDITOR'],
                         'alternative_names': 'Neubert, Matthias'
                     },
                     {
                         'full_name': 'Glashow, Sheldon Lee',
-                        'roles': ['editor']
+                        'roles': ['EDITOR']
                     },
                     {
                         'full_name': 'Van Dam, Hendrik',
-                        'roles': ['editor']
+                        'roles': ['EDITOR']
                     },
                     {
                         'full_name': 'Seyfert, Paul',
-                        'roles': ['author'],
+                        'roles': ['AUTHOR'],
                         'affiliations': [{'name': 'CERN'}],
                         'identifiers': [
                             {'scheme': 'INSPIRE ID',
@@ -669,13 +669,13 @@ def test_authors(app):
                     },
                     {
                         'full_name': 'John Doe',
-                        'roles': ['author'],
+                        'roles': ['AUTHOR'],
                         'affiliations': [{'name': 'CERN'},
                                          {'name': 'Univ. Gent'}],
                     },
                     {
                         'full_name': 'Jane Doe',
-                        'roles': ['author'],
+                        'roles': ['AUTHOR'],
                         'affiliations': [{'name': 'CERN'},
                                          {'name': 'Univ. Gent'}],
                     }
@@ -698,11 +698,11 @@ def test_authors(app):
                 'authors': [
                     {
                         'full_name': 'Frampton, Paul H',
-                        'roles': ['editor'],
+                        'roles': ['EDITOR'],
                     },
                     {
                         'full_name': 'Glashow, Sheldon Lee',
-                        'roles': ['editor']
+                        'roles': ['EDITOR']
                     },
                 ],
                 'other_authors': True,
@@ -1585,7 +1585,7 @@ def test_languages(app):
                 <subfield code="a">eng</subfield>
             </datafield>
             """, {
-                'languages': ['en'],
+                'languages': ['EN'],
             })
         check_transformation(
             """
@@ -1593,7 +1593,7 @@ def test_languages(app):
                 <subfield code="a">english</subfield>
             </datafield>
             """, {
-                'languages': ['en'],
+                'languages': ['EN'],
             })
         check_transformation(
             """
@@ -1601,7 +1601,7 @@ def test_languages(app):
                 <subfield code="a">fre</subfield>
             </datafield>
             """, {
-                'languages': ['fr'],
+                'languages': ['FR'],
             })
         check_transformation(
             """
@@ -1609,7 +1609,7 @@ def test_languages(app):
                 <subfield code="a">pl</subfield>
             </datafield>
             """, {
-                'languages': ['pl'],
+                'languages': ['PL'],
             })
         check_transformation(
             """
@@ -1617,7 +1617,7 @@ def test_languages(app):
                 <subfield code="a">ger</subfield>
             </datafield>
             """, {
-                'languages': ['de'],
+                'languages': ['DE'],
             })
         with pytest.raises(UnexpectedValue):
             check_transformation(
@@ -1626,7 +1626,7 @@ def test_languages(app):
                     <subfield code="a">xxxxxxxx</subfield>
                 </datafield>
                 """, {
-                    'languages': ['de'],
+                    'languages': ['DE'],
                 })
 
 
@@ -1639,7 +1639,7 @@ def test_editions(app):
                 <subfield code="a">3rd ed.</subfield>
             </datafield>
             """, {
-                'edition': '3rd ed.'
+                'edition': '3rd'
             })
 
 

--- a/tests/test_journals.py
+++ b/tests/test_journals.py
@@ -172,7 +172,7 @@ def test_languages(app):
             </datafield>
             """,
             {
-                'languages': ['en'],
+                'languages': ['EN'],
             }
         )
 


### PR DESCRIPTION
Closes partially CERNDocumentServer/cds-ils#154
- remove `ed.` from editions
- fix broken `language` and `author.roles` field